### PR TITLE
Utilisation systématique du tag <?php

### DIFF
--- a/moteur/login_post.php
+++ b/moteur/login_post.php
@@ -1,4 +1,4 @@
-<?
+<?php
 session_start();
 //martin vert
 // Connexion à la base de données


### PR DESCRIPTION
Le tag <? n'est pas accepté sur certains environements.

Je suggère d'utiliser le tag <?php partout pour éviter des problèmes.