### PR TITLE
recap des ventes par moyen de paiement

### DIFF
--- a/ifaces/bilanv.php
+++ b/ifaces/bilanv.php
@@ -779,6 +779,48 @@ $req->closeCursor(); // Termine le traitement de la requête ?>
         
         </tbody>
     </table>
+
+<?php
+// Tableau de recap du Chiffre d'Affaire par mode de paiement
+// Utile pour vérifier le fond de caisse en fin de vente
+// Equivalent de la touche 'Z' sur une caisse enregistreuse
+
+$sql =  file_get_contents('../mysql/recap_CA_par_mode_paiement.sql');
+$req = $bdd->prepare($sql);
+$ok = $req->execute(array('du' => $time_debut,'au' => $time_fin ,'numero' => $_GET['numero'] ));
+if ( ! $ok ) {
+	$erreur=$req->errorInfo()[2].' in '.$sql;
+	trigger_error($erreur,E_USER_ERROR);
+} 
+
+//Affichage du tableau
+print "<h2>Récapitulatif par mode de paiement</h2>";
+print "<table class='table table-hover'>";
+print "<thead>";
+print "<tr>";
+print "<th>Moyen de Paiement</th>";
+print "<th>Nombre de Ventes</th>";
+print "<th>Chiffre Dégagé</th>";
+print "<th>Remboursements</th>";
+print "</tr>";
+print "</tr>";
+print "</thead>";
+print "<tbody>";
+
+while ($ligne = $req->fetch())
+{
+print "<tr>";
+print "<td>".$ligne['moyen']."</td>";
+print "<td>".$ligne['quantite_vendue']."</td>";
+print "<td>".$ligne['total']."</td>";
+print "<td>".$ligne['remboursement']."</td>";
+print "</tr>";
+
+}
+print "</tbody>";
+print "</table>";
+?>
+
 </div>
 </div>
 <?php

--- a/mysql/recap_CA_par_mode_paiement.sql
+++ b/mysql/recap_CA_par_mode_paiement.sql
@@ -1,0 +1,26 @@
+--
+-- name : bilan_z.sql
+-- desc : récapitulatif des encaissements classés par moyen de paiement
+--
+-- params :
+--  :du = la date de debut
+--  :au = la date de fin
+--  :numero = id du point de vente
+
+SELECT 
+	ventes.id_moyen_paiement AS id_moyen, 
+	moyens_paiement.nom AS moyen,
+	COUNT(vendus.id) AS quantite_vendue, 
+	SUM(vendus.prix*vendus.quantite) AS total, 
+	SUM(vendus.remboursement) AS remboursement 
+FROM 
+	ventes,
+	vendus,
+	moyens_paiement 
+WHERE 
+	vendus.id_vente = ventes.id  
+   AND moyens_paiement.id = ventes.id_moyen_paiement 
+   AND DATE(vendus.timestamp) BETWEEN :du AND :au 
+   AND ventes.id_point_vente  = :numero
+GROUP BY ventes.id_moyen_paiement;
+


### PR DESCRIPTION
Tableau de recap du Chiffre d'Affaire par mode de paiement

Utile pour vérifier le fond de caisse en fin de vente

Equivalent de la touche 'Z' sur une caisse enregistreuse