### PR TITLE
Nettoyage dbconfig

### DIFF
--- a/ifaces/bilanc.php
+++ b/ifaces/bilanc.php
@@ -1,5 +1,6 @@
-
 <?php session_start();
+
+require_once('../moteur/dbconfig.php');
 
 //Vérification des autorisations de l'utilisateur et des variables de session requises pour l'affichage de cette page:
 if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($_SESSION['niveau'], 'bi') !== false))
@@ -154,18 +155,6 @@ if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($
 
  <?php 
           //on affiche un onglet par type d'objet
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
  
             // On recupère tout le contenu des visibles de la table type_dechets
             $reponse = $bdd->query('SELECT * FROM points_collecte');
@@ -219,17 +208,6 @@ $time_fin = $time_fin." 23:59:59";
 
            
 if ($_GET['numero'] == 0) {
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
-            // Si tout va bien, on peut continuer
             // On recupère tout le contenu de la table point de vente
 
 
@@ -245,17 +223,6 @@ echo $donnees['total']." Kgs.";
 else //si on observe un point en particulier
 {
 
-try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
-            // Si tout va bien, on peut continuer
             // On recupère tout le contenu de la table point de vente
 
 
@@ -282,21 +249,6 @@ if ($_GET['numero'] == 0) {
 // on determine le nombre de points de collecte
 
 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
-            /*
-
-            */
  $req = $bdd->prepare("SELECT COUNT(id) FROM points_collecte");//SELECT `titre_affectation` FROM affectations WHERE titre_affectation = "conssomables" LIMIT 1
 $req->execute(array('au' => $time_fin ));
 $donnees = $req->fetch();
@@ -339,18 +291,6 @@ $req->closeCursor(); // Termine le traitement de la requête
         if ($_GET['numero'] == 0) {
 
 // on determine les masses totales collèctés sur cete période(pour Tous les points)
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
  
             // On recupère tout le contenu de la table affectations
 
@@ -376,18 +316,6 @@ GROUP BY id_type_collecte');
         </tr>
 
       <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
  
             // On recupère tout le contenu de la table affectations
             $reponse2 = $bdd->prepare('SELECT type_dechets.couleur,type_dechets.nom, sum(pesees_collectes.masse) somme
@@ -432,19 +360,6 @@ ORDER BY somme DESC');
 
 
 // on determine les masses totales collèctés sur cete période(pour un point donné)
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu de la table affectations
 
             $reponse = $bdd->prepare('SELECT 
@@ -469,18 +384,6 @@ GROUP BY id_type_collecte');
             <td><?php echo  round($donnees['somme']*100/$mtotcolo, 2)   ; ?></td>      
         </tr>
       <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
  
             // On recupère tout le contenu de la table affectations
             $reponse2 = $bdd->prepare('SELECT type_dechets.couleur,type_dechets.nom, sum(pesees_collectes.masse) somme
@@ -588,18 +491,6 @@ ORDER BY somme DESC');
         if ($_GET['numero'] == 0) {
 
 // on determine les masses totales collèctés sur cete période(pour Tous les points)
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
  
             // On recupère tout le contenu de la table affectations
 
@@ -625,18 +516,6 @@ GROUP BY id');
         </tr>
 
       <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
  
             // On recupère tout le contenu de la table affectations
             $reponse2 = $bdd->prepare('SELECT localites.couleur,type_dechets.nom, sum(pesees_collectes.masse) somme
@@ -681,19 +560,6 @@ ORDER BY somme DESC');
 
 
 // on determine les masses totales collèctés sur cete période(pour un point donné)
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu de la table affectations
 
             $reponse = $bdd->prepare('SELECT 
@@ -719,19 +585,6 @@ GROUP BY id
             <td><?php echo  round($donnees['somme']*100/$mtotcolo, 2)   ; ?></td>      
         </tr>
       <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu de la table affectations
             $reponse2 = $bdd->prepare('SELECT type_dechets.couleur,type_dechets.nom, sum(pesees_collectes.masse) somme
  FROM type_dechets,pesees_collectes ,type_collecte , collectes
@@ -806,19 +659,6 @@ ORDER BY somme DESC');
 data: [
 <?php 
 if ($_GET['numero'] == 0) {
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout les masses collectés pour chaque type
             $reponse = $bdd->prepare('SELECT type_collecte.couleur,type_collecte.nom, sum(pesees_collectes.masse) somme 
               FROM type_collecte,pesees_collectes,collectes WHERE type_collecte.id = collectes.id_type_collecte AND pesees_collectes.id_collecte = collectes.id AND DATE(collectes.timestamp) BETWEEN :du AND :au
@@ -839,19 +679,6 @@ GROUP BY nom');
     labelColor: '#060',
     colors: [
 <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère les couleurs de chaque type
             $reponse = $bdd->prepare('SELECT type_collecte.couleur,type_collecte.nom, sum(pesees_collectes.masse) somme 
               FROM type_collecte,pesees_collectes,collectes WHERE type_collecte.id = collectes.id_type_collecte AND pesees_collectes.id_collecte = collectes.id AND DATE(collectes.timestamp) BETWEEN :du AND :au
@@ -873,22 +700,6 @@ GROUP BY nom');
 </script>
 <?php }
 else {
-
-
-
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu de la table affectations
             $reponse = $bdd->prepare('SELECT type_collecte.couleur,type_collecte.nom, sum(pesees_collectes.masse) somme 
               FROM type_collecte,pesees_collectes,collectes 
@@ -911,19 +722,6 @@ GROUP BY nom');
     labelColor: '#060',
     colors: [
 <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu de la table affectations
             $reponse = $bdd->prepare('SELECT type_collecte.couleur,type_collecte.nom, sum(pesees_collectes.masse) somme 
               FROM type_collecte,pesees_collectes,collectes 
@@ -954,19 +752,6 @@ GROUP BY nom');
 data: [
 <?php 
 if ($_GET['numero'] == 0) {
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout les masses collectés pour chaque type
             $reponse = $bdd->prepare('SELECT type_dechets.couleur,type_dechets.nom, sum(pesees_collectes.masse) somme 
               FROM type_dechets,pesees_collectes WHERE type_dechets.id = pesees_collectes.id_type_dechet AND pesees_collectes.timestamp BETWEEN :du AND :au
@@ -987,19 +772,6 @@ GROUP BY nom');
     labelColor: '#060',
     colors: [
 <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère les couleurs de chaque type
             $reponse = $bdd->prepare('SELECT type_dechets.couleur,type_dechets.nom, sum(pesees_collectes.masse) somme 
               FROM type_dechets,pesees_collectes WHERE type_dechets.id = pesees_collectes.id_type_dechet AND pesees_collectes.timestamp BETWEEN :du AND :au
@@ -1021,22 +793,6 @@ GROUP BY nom');
 </script>
 <?php }
 else {
-
-
-
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu de la table affectations
             $reponse = $bdd->prepare('SELECT type_dechets.couleur,type_dechets.nom, sum(pesees_collectes.masse) somme 
               FROM type_dechets,pesees_collectes,collectes 
@@ -1059,19 +815,6 @@ GROUP BY nom');
     labelColor: '#060',
     colors: [
 <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu de la table affectations
             $reponse = $bdd->prepare('SELECT type_dechets.couleur,type_dechets.nom, sum(pesees_collectes.masse) somme 
               FROM type_dechets,pesees_collectes,collectes 
@@ -1102,19 +845,6 @@ GROUP BY nom');
 data: [
 <?php 
 if ($_GET['numero'] == 0) {
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout les masses collectés pour chaque type
             $reponse = $bdd->prepare('SELECT localites.couleur,localites.nom, sum(distinct pesees_collectes.masse) somme 
               FROM type_dechets,pesees_collectes,collectes,localites WHERE localites.id = collectes.localisation AND pesees_collectes.id_collecte = collectes.id AND pesees_collectes.timestamp BETWEEN :du AND :au
@@ -1135,19 +865,6 @@ GROUP BY nom');
     labelColor: '#060',
     colors: [
 <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère les couleurs de chaque type
             $reponse = $bdd->prepare('SELECT localites.couleur,localites.nom, sum(distinct pesees_collectes.masse) somme 
               FROM type_dechets,pesees_collectes,collectes,localites WHERE localites.id = collectes.localisation AND pesees_collectes.id_collecte = collectes.id AND pesees_collectes.timestamp BETWEEN :du AND :au
@@ -1169,22 +886,6 @@ GROUP BY nom');
 </script>
 <?php }
 else {
-
-
-
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu de la table affectations
             $reponse = $bdd->prepare('SELECT localites.couleur,localites.nom, sum(pesees_collectes.masse) somme 
               FROM localites,pesees_collectes,collectes 
@@ -1207,19 +908,6 @@ GROUP BY nom');
     labelColor: '#060',
     colors: [
 <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu de la table affectations
             $reponse = $bdd->prepare('SELECT localites.couleur,localites.nom, sum(pesees_collectes.masse) somme 
               FROM localites,pesees_collectes,collectes 
@@ -1252,19 +940,6 @@ GROUP BY nom');
 data: [
 <?php 
 if ($_GET['numero'] == 0) {
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout les masses collectés pour chaque type
             $reponse = $bdd->prepare('SELECT type_dechets.couleur,type_dechets.nom, sum(pesees_collectes.masse) somme 
               FROM type_dechets,pesees_collectes WHERE type_dechets.id = pesees_collectes.id_type_dechet AND pesees_collectes.timestamp BETWEEN :du AND :au
@@ -1285,19 +960,6 @@ GROUP BY nom');
     labelColor: '#060',
     colors: [
 <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère les couleurs de chaque type
             $reponse = $bdd->prepare('SELECT type_dechets.couleur,type_dechets.nom, sum(pesees_collectes.masse) somme 
               FROM type_dechets,pesees_collectes WHERE type_dechets.id = pesees_collectes.id_type_dechet AND pesees_collectes.timestamp BETWEEN :du AND :au
@@ -1319,22 +981,6 @@ GROUP BY nom');
 </script>
 <?php }
 else {
-
-
-
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu de la table affectations
             $reponse = $bdd->prepare('SELECT type_dechets.couleur,type_dechets.nom, sum(pesees_collectes.masse) somme 
               FROM type_dechets,pesees_collectes,collectes 
@@ -1357,19 +1003,6 @@ GROUP BY nom');
     labelColor: '#060',
     colors: [
 <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu de la table affectations
             $reponse = $bdd->prepare('SELECT type_dechets.couleur,type_dechets.nom, sum(pesees_collectes.masse) somme 
               FROM type_dechets,pesees_collectes,collectes 

--- a/ifaces/bilanhb.php
+++ b/ifaces/bilanhb.php
@@ -1,4 +1,7 @@
 <?php session_start();
+
+require_once('../moteur/dbconfig.php');
+
 //Vérification des autorisations de l'utilisateur et des variables de session requises pour l'affichage de cette page:
 if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($_SESSION['niveau'], 'bi') !== false))
       { include "tete.php";?>
@@ -141,20 +144,6 @@ if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($
  
 
  <?php 
-          //on affiche un onglet par type d'objet
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu des visibles de la table type_dechets
             $reponse = $bdd->query('SELECT * FROM points_sortie');
  
@@ -196,17 +185,6 @@ $time_fin = $time_fin." 23:59:59";
 // on determine la masse totale collecté sur cette période (pour tous les points)
            
 if ($_GET['numero'] == 0) {
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
-            // Si tout va bien, on peut continuer
             // On recupère tout le contenu de la table point de vente
 $req = $bdd->prepare("SELECT SUM(pesees_sorties.masse)AS total   FROM pesees_sorties  WHERE  pesees_sorties.timestamp BETWEEN :du AND :au ");
 $req->execute(array('du' => $time_debut,'au' => $time_fin ));
@@ -219,17 +197,6 @@ echo $donnees['total']." Kgs.";
 }
 else //si on observe un point en particulier
 {
-try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
-            // Si tout va bien, on peut continuer
             // On recupère tout le contenu de la table point de vente
 $req = $bdd->prepare("SELECT SUM(pesees_sorties.masse)AS total  
 FROM pesees_sorties ,sorties
@@ -246,18 +213,6 @@ if ($_GET['numero'] == 0) {
   ?>
   , sur <?php
 // on determine le nombre de points de collecte
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
             /*
             */
  $req = $bdd->prepare("SELECT COUNT(id) FROM points_sortie");//SELECT `titre_affectation` FROM affectations WHERE titre_affectation = "conssomables" LIMIT 1
@@ -297,19 +252,6 @@ $req->closeCursor(); // Termine le traitement de la requête
         <?php
         if ($_GET['numero'] == 0) {
 // on determine les masses totales collèctés sur cete période(pour Tous les points)
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu de la table affectations
             $reponse = $bdd->prepare('SELECT 
 SUM(pesees_sorties.masse) somme,pesees_sorties.timestamp,sorties.classe,COUNT(distinct sorties.id) ncol
@@ -356,19 +298,6 @@ default; ?>
         </tr>
 
       <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu de la table affectations
             $reponse2 = $bdd->prepare('SELECT 
 type_dechets.couleur,
@@ -416,19 +345,6 @@ GROUP BY nom');
                }else
                {
 // on determine les masses totales collèctés sur cete période(pour un point donné)
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu de la table affectations
             $reponse = $bdd->prepare('SELECT 
 type_collecte.nom,SUM(`pesees_collectes`.`masse`) somme,pesees_collectes.timestamp,type_collecte.id,COUNT(distinct collectes.id) ncol
@@ -451,19 +367,6 @@ GROUP BY id_type_collecte');
             <td><?php echo  round($donnees['somme']*100/$mtotcolo, 2)   ; ?></td>      
         </tr>
       <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu de la table affectations
             $reponse2 = $bdd->prepare('SELECT type_dechets.couleur,type_dechets.nom, sum(pesees_collectes.masse) somme
  FROM type_dechets,pesees_collectes ,type_collecte , collectes
@@ -568,19 +471,6 @@ ORDER BY somme DESC');
         <?php
         if ($_GET['numero'] == 0) {
 // on determine les masses totales collèctés sur cete période(pour Tous les points)
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu de la table affectations
             $reponse = $bdd->prepare('SELECT 
 localites.nom,SUM(pesees_collectes.masse) somme,pesees_collectes.timestamp,localites.id id,COUNT(distinct collectes.id) ncol
@@ -603,19 +493,6 @@ GROUP BY id');
         </tr>
 
       <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu de la table affectations
             $reponse2 = $bdd->prepare('SELECT localites.couleur,type_dechets.nom, sum(pesees_collectes.masse) somme
  FROM type_dechets,pesees_collectes ,localites , collectes
@@ -655,19 +532,6 @@ ORDER BY somme DESC');
                }else
                {
 // on determine les masses totales collèctés sur cete période(pour un point donné)
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu de la table affectations
             $reponse = $bdd->prepare('SELECT 
 localites.nom,SUM(pesees_collectes.masse) somme,pesees_collectes.timestamp,localites.id,COUNT(distinct collectes.id) ncol
@@ -691,19 +555,6 @@ GROUP BY id
             <td><?php echo  round($donnees['somme']*100/$mtotcolo, 2)   ; ?></td>      
         </tr>
       <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu de la table affectations
             $reponse2 = $bdd->prepare('SELECT type_dechets.couleur,type_dechets.nom, sum(pesees_collectes.masse) somme
  FROM type_dechets,pesees_collectes ,type_collecte , collectes
@@ -777,19 +628,6 @@ ORDER BY somme DESC');
 data: [
 <?php 
 if ($_GET['numero'] == 0) {
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout les masses collectés pour chaque type
             $reponse = $bdd->prepare('SELECT type_collecte.couleur,type_collecte.nom, sum(pesees_collectes.masse) somme 
               FROM type_collecte,pesees_collectes,collectes WHERE type_collecte.id = collectes.id_type_collecte AND pesees_collectes.id_collecte = collectes.id AND DATE(collectes.timestamp) BETWEEN :du AND :au
@@ -807,19 +645,6 @@ GROUP BY nom');
     labelColor: '#060',
     colors: [
 <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère les couleurs de chaque type
             $reponse = $bdd->prepare('SELECT type_collecte.couleur,type_collecte.nom, sum(pesees_collectes.masse) somme 
               FROM type_collecte,pesees_collectes,collectes WHERE type_collecte.id = collectes.id_type_collecte AND pesees_collectes.id_collecte = collectes.id AND DATE(collectes.timestamp) BETWEEN :du AND :au
@@ -838,19 +663,6 @@ GROUP BY nom');
 </script>
 <?php }
 else {
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu de la table affectations
             $reponse = $bdd->prepare('SELECT type_collecte.couleur,type_collecte.nom, sum(pesees_collectes.masse) somme 
               FROM type_collecte,pesees_collectes,collectes 
@@ -870,19 +682,6 @@ GROUP BY nom');
     labelColor: '#060',
     colors: [
 <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu de la table affectations
             $reponse = $bdd->prepare('SELECT type_collecte.couleur,type_collecte.nom, sum(pesees_collectes.masse) somme 
               FROM type_collecte,pesees_collectes,collectes 
@@ -910,19 +709,6 @@ GROUP BY nom');
 data: [
 <?php 
 if ($_GET['numero'] == 0) {
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout les masses collectés pour chaque type
             $reponse = $bdd->prepare('SELECT type_dechets.couleur,type_dechets.nom, sum(pesees_collectes.masse) somme 
               FROM type_dechets,pesees_collectes WHERE type_dechets.id = pesees_collectes.id_type_dechet AND pesees_collectes.timestamp BETWEEN :du AND :au
@@ -940,19 +726,6 @@ GROUP BY nom');
     labelColor: '#060',
     colors: [
 <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère les couleurs de chaque type
             $reponse = $bdd->prepare('SELECT type_dechets.couleur,type_dechets.nom, sum(pesees_collectes.masse) somme 
               FROM type_dechets,pesees_collectes WHERE type_dechets.id = pesees_collectes.id_type_dechet AND pesees_collectes.timestamp BETWEEN :du AND :au
@@ -971,19 +744,6 @@ GROUP BY nom');
 </script>
 <?php }
 else {
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu de la table affectations
             $reponse = $bdd->prepare('SELECT type_dechets.couleur,type_dechets.nom, sum(pesees_collectes.masse) somme 
               FROM type_dechets,pesees_collectes,collectes 
@@ -1003,19 +763,6 @@ GROUP BY nom');
     labelColor: '#060',
     colors: [
 <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu de la table affectations
             $reponse = $bdd->prepare('SELECT type_dechets.couleur,type_dechets.nom, sum(pesees_collectes.masse) somme 
               FROM type_dechets,pesees_collectes,collectes 
@@ -1043,19 +790,6 @@ GROUP BY nom');
 data: [
 <?php 
 if ($_GET['numero'] == 0) {
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout les masses collectés pour chaque type
             $reponse = $bdd->prepare('SELECT localites.couleur,localites.nom, sum(distinct pesees_collectes.masse) somme 
               FROM type_dechets,pesees_collectes,collectes,localites WHERE localites.id = collectes.localisation AND pesees_collectes.id_collecte = collectes.id AND pesees_collectes.timestamp BETWEEN :du AND :au
@@ -1073,19 +807,6 @@ GROUP BY nom');
     labelColor: '#060',
     colors: [
 <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère les couleurs de chaque type
             $reponse = $bdd->prepare('SELECT localites.couleur,localites.nom, sum(distinct pesees_collectes.masse) somme 
               FROM type_dechets,pesees_collectes,collectes,localites WHERE localites.id = collectes.localisation AND pesees_collectes.id_collecte = collectes.id AND pesees_collectes.timestamp BETWEEN :du AND :au
@@ -1104,19 +825,6 @@ GROUP BY nom');
 </script>
 <?php }
 else {
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu de la table affectations
             $reponse = $bdd->prepare('SELECT localites.couleur,localites.nom, sum(pesees_collectes.masse) somme 
               FROM localites,pesees_collectes,collectes 
@@ -1136,19 +844,6 @@ GROUP BY nom');
     labelColor: '#060',
     colors: [
 <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu de la table affectations
             $reponse = $bdd->prepare('SELECT localites.couleur,localites.nom, sum(pesees_collectes.masse) somme 
               FROM localites,pesees_collectes,collectes 
@@ -1178,19 +873,6 @@ GROUP BY nom');
 data: [
 <?php 
 if ($_GET['numero'] == 0) {
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout les masses collectés pour chaque type
             $reponse = $bdd->prepare('SELECT type_dechets.couleur,type_dechets.nom, sum(pesees_collectes.masse) somme 
               FROM type_dechets,pesees_collectes WHERE type_dechets.id = pesees_collectes.id_type_dechet AND pesees_collectes.timestamp BETWEEN :du AND :au
@@ -1208,19 +890,6 @@ GROUP BY nom');
     labelColor: '#060',
     colors: [
 <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère les couleurs de chaque type
             $reponse = $bdd->prepare('SELECT type_dechets.couleur,type_dechets.nom, sum(pesees_collectes.masse) somme 
               FROM type_dechets,pesees_collectes WHERE type_dechets.id = pesees_collectes.id_type_dechet AND pesees_collectes.timestamp BETWEEN :du AND :au
@@ -1239,19 +908,6 @@ GROUP BY nom');
 </script>
 <?php }
 else {
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu de la table affectations
             $reponse = $bdd->prepare('SELECT type_dechets.couleur,type_dechets.nom, sum(pesees_collectes.masse) somme 
               FROM type_dechets,pesees_collectes,collectes 
@@ -1271,19 +927,6 @@ GROUP BY nom');
     labelColor: '#060',
     colors: [
 <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu de la table affectations
             $reponse = $bdd->prepare('SELECT type_dechets.couleur,type_dechets.nom, sum(pesees_collectes.masse) somme 
               FROM type_dechets,pesees_collectes,collectes 

--- a/ifaces/bilanv.php
+++ b/ifaces/bilanv.php
@@ -1,5 +1,7 @@
-
 <?php session_start();
+
+require_once('../moteur/dbconfig.php');
+
 //Vérification des autorisations de l'utilisateur et des variables de session requises pour l'affichage de cette page:
 if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($_SESSION['niveau'], 'bi') !== false))
       { include "tete.php";?>
@@ -113,19 +115,6 @@ if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($
         <h2> Bilan des ventes de la structure</h2>
         <ul class="nav nav-tabs">
         <?php      //on affiche un onglet par point de vente
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu des visibles de la table points_vente
             $reponse = $bdd->query('SELECT * FROM points_vente');
  
@@ -173,18 +162,6 @@ if ($_GET['numero'] == 0) // si numero == 0*************************************
   <?php
   echo "-nombre de points de vente : ";
   // on determine le nombre de points de vente à cet instant
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
             /*
 
             */
@@ -194,17 +171,6 @@ if ($_GET['numero'] == 0) // si numero == 0*************************************
 echo $donnees['COUNT(id)']."<br>";
 
   echo "-chiffre total dégagé  : ";
- try
- {
-  // On se connecte à MySQL
-  include('../moteur/dbconfig.php');
-  }
-  catch(Exception $e)
-  {
-  // En cas d'erreur, on affiche un message et on arrête tout
-  die('Erreur : '.$e->getMessage());
-  }
-  // Si tout va bien, on peut continuer
   // On recupère tout le contenu de la table point de vente
   $req = $bdd->prepare("SELECT  SUM(vendus.prix*vendus.quantite) AS total   FROM vendus 
    WHERE  DATE(vendus.timestamp) BETWEEN :du AND :au AND vendus.prix > 0  ");
@@ -215,18 +181,6 @@ echo $donnees['COUNT(id)']."<br>";
   $req->closeCursor(); // Termine le traitement de la requête
  echo "-nombre d'objets vendus : ";
 // on determine le nombre d'objets vendus
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
             /*
 
             */
@@ -236,18 +190,6 @@ echo $donnees['COUNT(id)']."<br>";
 echo $donnees['SUM(vendus.quantite)']."<br>";
  echo "-nombre de ventes : ";
 // on determine le nombre de ventes
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
             /*
 
             */
@@ -260,18 +202,6 @@ echo $donnees['COUNT(ventes.id)']."<br>";
 
   echo "-nombre d'objets remboursés : ";
   // on determine le nombre d'objets remboursés
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
             /*
 
             */
@@ -281,18 +211,6 @@ echo $donnees['COUNT(ventes.id)']."<br>";
 echo intval($donnees['SUM(vendus.quantite)'])."<br>";
   echo "-nombre de remboursemments : ";
   // on determine le nombre de remboursements
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
             /*
 
             */
@@ -302,17 +220,6 @@ echo intval($donnees['SUM(vendus.quantite)'])."<br>";
 echo $donnees['COUNT(ventes.id)']."<br>";
 
   echo "-somme remboursée : ";
-try
- {
-  // On se connecte à MySQL
-  include('../moteur/dbconfig.php');
-  }
-  catch(Exception $e)
-  {
-  // En cas d'erreur, on affiche un message et on arrête tout
-  die('Erreur : '.$e->getMessage());
-  }
-  // Si tout va bien, on peut continuer
   // On recupère tout le contenu de la table point de vente
   $req = $bdd->prepare("SELECT  SUM(vendus.remboursement) AS total   FROM vendus  WHERE  DATE(vendus.timestamp) BETWEEN :du AND :au  ");
   $req->execute(array('du' => $time_debut,'au' => $time_fin ));
@@ -342,19 +249,6 @@ chiffre de caisse : <?php echo  $mtotcolo- $mtotcolo2." €";?>
       </thead>
       <tbody>
 <?php
- try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu de la table affectations
             $reponse2 = $bdd->prepare('SELECT type_dechets.id id,
    type_dechets.nom ,SUM(vendus.prix*vendus.quantite) total 
@@ -380,18 +274,6 @@ GROUP BY type_dechets.nom
             <td >
               <?php
                 // on determine le nombre d'objets vendus
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
             /*
 
             */
@@ -403,17 +285,7 @@ echo $donnees['SUM(vendus.quantite)'];
 $req->closeCursor(); // Termine le traitement de la requête ?>
             </td>
             <td>
-              <?php try
- {
-  // On se connecte à MySQL
-  include('../moteur/dbconfig.php');
-  }
-  catch(Exception $e)
-  {
-  // En cas d'erreur, on affiche un message et on arrête tout
-  die('Erreur : '.$e->getMessage());
-  }
-  // Si tout va bien, on peut continuer
+              <?php 
   // On recupère tout le contenu de la table point de vente
   $req3 = $bdd->prepare("SELECT  SUM(vendus.remboursement) AS total   FROM vendus 
    WHERE  DATE(vendus.timestamp) BETWEEN :du AND :au AND vendus.id_type_dechet = :id  ");
@@ -427,18 +299,6 @@ $req->closeCursor(); // Termine le traitement de la requête ?>
             <td >
               <?php
                 // on determine le nombre d'objets remboursés
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
             /*
 
             */
@@ -482,17 +342,6 @@ else // si numero ==! 0*********************************************************
   <div class="col-md-6">
   <?php
 echo "-chiffre total dégagé :  ";
-try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
-            // Si tout va bien, on peut continuer
             // On recupère tout le contenu de la table point de vente
 
 
@@ -507,18 +356,6 @@ echo $donnees['total']." €.<br>";
 $req->closeCursor(); // Termine le traitement de la requête
 echo "-nombre d'objets vendus : ";
 // on determine le nombre d'objets vendus
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
             /*
 
             */
@@ -528,18 +365,6 @@ echo "-nombre d'objets vendus : ";
  echo $donnees['SUM(vendus.quantite)']."<br>";
  echo "-nombre de ventes : ";
  // on determine le nombre de ventes
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
             /*
 
             */
@@ -550,18 +375,6 @@ echo $donnees['COUNT(ventes.id)']."<br>";
 
 echo "-nombre de ventes : ";
 // on determine le nombre de ventes
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
             /*
 
             */
@@ -573,18 +386,6 @@ echo $donnees['COUNT(ventes.id)']."<br>";
 echo "-panier moyen : ".$mtotcolo/$nventes." € <br>";
 echo "-nombre d'objets remboursés : ";
 // on determine le nombre d'objets remboursés
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
             /*
 
             */
@@ -594,18 +395,6 @@ echo "-nombre d'objets remboursés : ";
 echo intval($donnees['SUM(vendus.quantite)'])."<br>";
 echo "-nombre de remboursemments : ";
 // on determine le nombre de remboursements
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
             /*
 
             */
@@ -615,18 +404,6 @@ echo "-nombre de remboursemments : ";
 echo $donnees['COUNT(ventes.id)']."<br>";
 echo "-somme remboursée : ";
 
-try
- {
- 
-  // On se connecte à MySQL
-  include('../moteur/dbconfig.php');
-  }
-  catch(Exception $e)
-  {
-  // En cas d'erreur, on affiche un message et on arrête tout
-  die('Erreur : '.$e->getMessage());
-  }
-  // Si tout va bien, on peut continuer
   // On recupère tout le contenu de la table point de vente
   $req = $bdd->prepare("SELECT  SUM(vendus.remboursement) AS total   FROM vendus,ventes  WHERE  DATE(vendus.timestamp) BETWEEN :du AND :au  AND ventes.id_point_vente  = :numero 
     AND ventes.id = vendus.id_vente ");
@@ -656,19 +433,6 @@ chiffre de caisse : <?php echo  $mtotcolo- $mtotcolo2." €";?>
       </thead>
       <tbody>
 <?php
- try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu de la table affectations
             $reponse2 = $bdd->prepare('SELECT type_dechets.id id,
    type_dechets.nom ,SUM(vendus.prix*vendus.quantite) total 
@@ -694,18 +458,6 @@ GROUP BY type_dechets.nom
             <td >
               <?php
                 // on determine le nombre d'objets vendus
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
             /*
 
             */
@@ -717,17 +469,7 @@ echo $donnees['SUM(vendus.quantite)'];
 $req->closeCursor(); // Termine le traitement de la requête ?>
             </td>
             <td>
-              <?php try
- {
-  // On se connecte à MySQL
-  include('../moteur/dbconfig.php');
-  }
-  catch(Exception $e)
-  {
-  // En cas d'erreur, on affiche un message et on arrête tout
-  die('Erreur : '.$e->getMessage());
-  }
-  // Si tout va bien, on peut continuer
+              <?php 
   // On recupère tout le contenu de la table point de vente
   $req3 = $bdd->prepare("SELECT  SUM(vendus.remboursement) AS total   FROM vendus,ventes 
    WHERE  DATE(vendus.timestamp) BETWEEN :du AND :au AND vendus.id_type_dechet = :id  AND ventes.id = vendus.id_vente AND ventes.id_point_vente  = :numero");
@@ -741,18 +483,6 @@ $req->closeCursor(); // Termine le traitement de la requête ?>
             <td >
               <?php
                 // on determine le nombre d'objets remboursés
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
             /*
 
             */

--- a/ifaces/collecte.php
+++ b/ifaces/collecte.php
@@ -1,4 +1,7 @@
 <?php session_start();
+
+require_once('../moteur/dbconfig.php');
+
 //Vérification des autorisations de l'utilisateur et des variables de session requises pour l'affichage de cette page:
  if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($_SESSION['niveau'], 'c'.$_GET['numero']) !== false))
       {include "tete.php";
@@ -13,16 +16,6 @@
 //
 
 //on obtient la masse maximum suportée par la balance de ce point de collecte dans la variable $pesee_max
-  try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
             //on obtient le nom du point de collecte designé par $GET['numero']
             $req = $bdd->prepare("SELECT pesee_max FROM points_collecte WHERE id = :id ");
             $req->execute(array('id' => $_GET['numero']));
@@ -81,16 +74,6 @@ function encaisse() {
 
 
  var mtot =<?php 
-                      try
-                      {
-                      // On se connecte à MySQL
-                      include('../moteur/dbconfig.php');
-                      }
-                      catch(Exception $e)
-                      {
-                      // En cas d'erreur, on affiche un message et on arrête tout
-                      die('Erreur : '.$e->getMessage());
-                      }
                       // On obtient tous les visibles de la table type_dechets de manière à cacluler mtot...
                       $reponse = $bdd->query('SELECT * FROM type_dechets WHERE visible = "oui"' );
                       // On affiche chaque entrée une à une
@@ -129,16 +112,6 @@ function encaisse() {
           function tdechet_clear()
           {
                       <?php 
-                      try
-                      {
-                      // On se connecte à MySQL
-                      include('../moteur/dbconfig.php');
-                      }
-                      catch(Exception $e)
-                      {
-                      // En cas d'erreur, on affiche un message et on arrête tout
-                      die('Erreur : '.$e->getMessage());
-                      }
                       // On obtient tous les visibles de la table type_dechets de manière à remettre à zéro tout les items du bon d'apport volontaire
                       $reponse = $bdd->query('SELECT * FROM type_dechets WHERE visible = "oui"' );
                       // On affiche chaque entrée une à une
@@ -179,16 +152,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
        <legend>
         <h2>
         <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
             //on obtient le nom du point de collecte designé par $GET['numero']
             $req = $bdd->prepare("SELECT * FROM points_collecte WHERE id = :id ");
             $req->execute(array('id' => $_GET['numero']));
@@ -222,19 +185,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
 <?php }?>
   <div class="panel-body" id="divID"> 
 <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // on affiche le bon de sortie hors-boutique (à zéro) correspondant aux types de déchets visibles
             $reponse = $bdd->query('SELECT * FROM type_dechets WHERE visible = "oui"');
             // On affiche chaque entrée une à une
@@ -279,16 +229,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
        <option value="0" selected="selected"></option> 
 
             <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
             // On affiche une liste déroulante des types de collecte visibles
             $reponse = $bdd->query('SELECT * FROM type_collecte WHERE visible = "oui"');
             // On affiche chaque entrée une à une
@@ -306,16 +246,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
      font-size : 12pt" required>
        <option value="0" selected="selected"></option>
             <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
             // On affiche une liste déroulante des localités visibles
             $reponse = $bdd->query('SELECT * FROM localites WHERE visible = "oui"');
             // On affiche chaque entrée une à une
@@ -359,16 +289,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
         <ul class="dropdown-menu dropdown-menu-right" role="menu">
         
   <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
             // On affiche une liste déroulante des localités visibles
             $reponse = $bdd->query('SELECT * FROM type_contenants WHERE visible = "oui"');
             // On affiche chaque entrée une à une
@@ -439,16 +359,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
 
 
             <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
             // On recupère tout le contenu de la table point de collecte
             $reponse = $bdd->query('SELECT * FROM type_dechets WHERE visible = "oui"');
  

--- a/ifaces/edition_conventions_sortie.php
+++ b/ifaces/edition_conventions_sortie.php
@@ -1,5 +1,7 @@
 <?php session_start(); 
 
+require_once('../moteur/dbconfig.php');
+
 //Vérification des autorisations de l'utilisateur et des variables de session requises pour l'affichage de cette page: 
     if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($_SESSION['niveau'], 'j') !== false))
       
@@ -62,19 +64,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
         </thead>
         <tbody>
         <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu de la table affectations
             $reponse = $bdd->query('SELECT * FROM conventions_sorties');
  

--- a/ifaces/edition_description.php
+++ b/ifaces/edition_description.php
@@ -1,5 +1,8 @@
  <?php session_start(); 
 
+
+require_once('../moteur/dbconfig.php');
+
 //Vérification des autorisations de l'utilisateur et des variables de session requises pour l'affichage de cette page: 
             if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($_SESSION['niveau'], 'k') !== false))
 
@@ -14,17 +17,6 @@
   <div class="panel-heading"> 
   </div>
             <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
-            // Si tout va bien, on peut continuer
             // On recupère tout le contenu de la table description structure
             $reponse = $bdd->query('SELECT * FROM description_structure');
             // On affiche chaque entree une à une

--- a/ifaces/edition_filieres_sortie.php
+++ b/ifaces/edition_filieres_sortie.php
@@ -1,4 +1,6 @@
 <?php session_start();
+
+require_once('../moteur/dbconfig.php');
  
 //Vérification des autorisations de l'utilisateur et des variables de session requises pour l'affichage de cette page: 
     if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($_SESSION['niveau'], 'j') !== false))
@@ -40,16 +42,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
 <label>Type de déchets enlevés:</label>
 <select name="id_dechet" id="id_dechet" class="form-control " required>
             <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
             // On affiche une liste déroulante des type de collecte visibles
             $reponse = $bdd->query('SELECT * FROM type_dechets_evac WHERE visible = "oui"');
             // On affiche chaque entrée une à une

--- a/ifaces/edition_filieres_sortie.php
+++ b/ifaces/edition_filieres_sortie.php
@@ -81,24 +81,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
         </thead>
         <tbody>
         <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
-
-
-
-
-
- 
             // On reccupère toute la liste des filières de sortie
             $reponse = $bdd->query('SELECT filieres_sortie.id, 
                                            filieres_sortie.timestamp, 

--- a/ifaces/edition_localites.php
+++ b/ifaces/edition_localites.php
@@ -1,4 +1,6 @@
-                <?php session_start(); 
+<?php session_start();
+
+require_once('../moteur/dbconfig.php'); 
 
 //Vérification des autorisations de l'utilisateur et des variables de session requises pour l'affichage de cette page: 
                 if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($_SESSION['niveau'], 'k') !== false))
@@ -57,16 +59,6 @@
 </thead>
 <tbody>
             <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
             $reponse = $bdd->query('SELECT * FROM localites');
             // On affiche chaque entree une à une
             while ($donnees = $reponse->fetch())

--- a/ifaces/edition_mdp_admin.php
+++ b/ifaces/edition_mdp_admin.php
@@ -1,4 +1,6 @@
-                    <?php session_start();
+<?php session_start();
+
+
 
 //Vérification des autorisations de l'utilisateur et des variables de session requises pour l'affichage de cette page: 
                     if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($_SESSION['niveau'], 'l') !== false))

--- a/ifaces/edition_points_collecte.php
+++ b/ifaces/edition_points_collecte.php
@@ -1,4 +1,6 @@
-                    <?php session_start();
+<?php session_start();
+
+require_once('../moteur/dbconfig.php');
 
 //Vérification des autorisations de l'utilisateur et des variables de session requises pour l'affichage de cette page:
                     if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($_SESSION['niveau'], 'k') !== false))
@@ -55,16 +57,6 @@
     </thead>
   <tbody>
                        <?php 
-                        try
-                        {
-                        // On se connecte à MySQL
-                        include('../moteur/dbconfig.php');
-                        }
-                        catch(Exception $e)
-                        {
-                        // En cas d'erreur, on affiche un message et on arrête tout
-                        die('Erreur : '.$e->getMessage());
-                        }
                         // On recupère tout le contenu de la table points-collecte
                         $reponse = $bdd->query('SELECT * FROM points_collecte');
                         // On affiche chaque entree une à une

--- a/ifaces/edition_points_sorties.php
+++ b/ifaces/edition_points_sorties.php
@@ -1,4 +1,6 @@
-                        <?php session_start(); 
+<?php session_start(); 
+
+require_once('../moteur/dbconfig.php');
 
 //Vérification des autorisations de l'utilisateur et des variables de session requises pour l'affichage de cette page:
                         if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($_SESSION['niveau'], 'k') !== false))
@@ -53,17 +55,6 @@
    </thead>
    <tbody>
                         <?php 
-                        try
-                        {
-                        // On se connecte à MySQL
-                        include('../moteur/dbconfig.php');
-                        }
-                        catch(Exception $e)
-                        {
-                        // En cas d'erreur, on affiche un message et on arrête tout
-                        die('Erreur : '.$e->getMessage());
-                        }
-                        // Si tout va bien, on peut continuer
                         // On recupère tout le contenu de la table affectations
                         $reponse = $bdd->query('SELECT * FROM points_sortie');
                                      // On affiche chaque entree une à une

--- a/ifaces/edition_points_vente.php
+++ b/ifaces/edition_points_vente.php
@@ -1,5 +1,7 @@
 <?php session_start(); 
 
+require_once('../moteur/dbconfig.php');
+
 //Vérification des autorisations de l'utilisateur et des variables de session requisent pour l'affichage de cette page:
     if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($_SESSION['niveau'], 'k') !== false))
       { include "tete.php" ?>
@@ -59,19 +61,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
         </thead>
         <tbody>
         <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu de la table affectations
             $reponse = $bdd->query('SELECT * FROM points_vente');
  

--- a/ifaces/edition_types_contenants.php
+++ b/ifaces/edition_types_contenants.php
@@ -1,5 +1,7 @@
 <?php session_start();
 
+require_once('../moteur/dbconfig.php');
+
 //Vérification des autorisations de l'utilisateur et des variables de session requisent pour l'affichage de cette page:
     if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($_SESSION['niveau'], 'g') !== false))
       { include "tete.php" ?>
@@ -58,19 +60,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
         </thead>
         <tbody>
         <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu de la table affectations
             $reponse = $bdd->query('SELECT * FROM type_contenants');
  

--- a/ifaces/edition_types_poubelles.php
+++ b/ifaces/edition_types_poubelles.php
@@ -1,5 +1,7 @@
 <?php session_start(); 
 
+require_once('../moteur/dbconfig.php');
+
 //Vérification des autorisations de l'utilisateur et des variables de session requisent pour l'affichage de cette page:
    if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($_SESSION['niveau'], 'g') !== false))
       { include "tete.php" ?>
@@ -60,19 +62,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
         </thead>
         <tbody>
         <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu de la table affectations
             $reponse = $bdd->query('SELECT * FROM types_poubelles');
  

--- a/ifaces/edition_types_sortie.php
+++ b/ifaces/edition_types_sortie.php
@@ -1,5 +1,7 @@
 <?php session_start(); 
 
+require_once('../moteur/dbconfig.php');
+
 //Vérification des autorisations de l'utilisateur et des variables de session requises pour l'affichage de cette page:
     if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($_SESSION['niveau'], 'k') !== false))
       { include "tete.php" ?>
@@ -55,19 +57,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
         </thead>
         <tbody>
         <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu de la table affectations
             $reponse = $bdd->query('SELECT * FROM type_sortie');
  

--- a/ifaces/edition_utilisateur.php
+++ b/ifaces/edition_utilisateur.php
@@ -1,5 +1,7 @@
 <?php session_start(); 
 
+require_once('../moteur/dbconfig.php');
+
 //Vérification des autorisations de l'utilisateur et des variables de session requisent pour l'affichage de cette page:
      if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($_SESSION['niveau'], 'l') !== false))
       {  include "tete.php" ?>
@@ -63,18 +65,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
   </div>
 <div class="col-md-4"><div class="alert alert-info"><label for="niveauc">Points de collecte:</label><br>
 <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
-            // Si tout va bien, on peut continuer
-            // On recupère tout le contenu de la table point de collecte
             $reponse = $bdd->query('SELECT * FROM points_collecte');
             // On affiche chaque entree une à une
            while ($donnees = $reponse->fetch())
@@ -89,17 +79,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
           
                                             <div class="alert alert-info"><label for="niveauv">Points de vente:</label><br>
           <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
-            // Si tout va bien, on peut continuer
             // On recupère tout le contenu de la table point de vente
             $reponse = $bdd->query('SELECT * FROM points_vente');
             // On affiche chaque entree une à une
@@ -119,17 +98,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
                  ?></div>
                                             <div class="alert alert-info"><label for="niveaus">Points de sortie hors-boutique:</label><br>
           <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
-            // Si tout va bien, on peut continuer
             // On recupère tout le contenu de la table point de vente
             $reponse = $bdd->query('SELECT * FROM points_sortie');
             // On affiche chaque entree une à une

--- a/ifaces/edition_utilisateurs.php
+++ b/ifaces/edition_utilisateurs.php
@@ -1,5 +1,7 @@
 <?php session_start(); 
 
+require_once('../moteur/dbconfig.php');
+
 //Vérification des autorisations de l'utilisateur et des variables de session requisent pour l'affichage de cette page:
      if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($_SESSION['niveau'], 'l') !== false))
       {  include "tete.php" ?>
@@ -58,19 +60,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
         </thead>
         <tbody>
         <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu de la table affectations
             $reponse = $bdd->query('SELECT * FROM utilisateurs');
  

--- a/ifaces/grilles_prix.php
+++ b/ifaces/grilles_prix.php
@@ -1,5 +1,7 @@
 <?php session_start(); 
 
+require_once('../moteur/dbconfig.php');
+
 //Vérification des autorisations de l'utilisateur et des variables de session requisent pour l'affichage de cette page:
   if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($_SESSION['niveau'], 'g') !== false))
       {  include "tete.php" ?>
@@ -33,18 +35,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
 
  <?php 
           //on affiche un onglet par type d'objet
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
  
             // On recupère tout le contenu des visibles de la table type_dechets
             $reponse = $bdd->query('SELECT * FROM type_dechets WHERE visible = "oui" ');
@@ -102,24 +92,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
         </thead>
         <tbody>
         <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
-
-
-
-
-
- 
             // On recupère toute la liste des filieres de sortie
             //   $reponse = $bdd->query('SELECT * FROM grille_objets');
           

--- a/ifaces/index.php
+++ b/ifaces/index.php
@@ -1,7 +1,6 @@
-
-
-
 <?php session_start(); 
+
+require_once("../moteur/dbconfig.php");
 
 //Vérification du renseignement du champ "id" (dans le tableau $_SESSION) et du fait que la variable "système" de ce même tableau a bien la valeur "oressource" avant d'afficher quoique ce soit:    
 if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource")
@@ -68,19 +67,6 @@ if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($
     element: 'graphj',
     data: [
 <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu de la table affectations
             $reponse = $bdd->query('SELECT type_dechets.couleur,type_dechets.nom, sum(pesees_collectes.masse) somme FROM type_dechets,pesees_collectes WHERE type_dechets.id = pesees_collectes.id_type_dechet AND DATE(pesees_collectes.timestamp) = CURDATE()
 GROUP BY nom');
@@ -100,19 +86,6 @@ GROUP BY nom');
     labelColor: '#060',
     colors: [
 <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu de la table affectations
             $reponse = $bdd->query('SELECT type_dechets.couleur,type_dechets.nom, sum(pesees_collectes.masse) somme FROM type_dechets,pesees_collectes WHERE type_dechets.id = pesees_collectes.id_type_dechet AND DATE(pesees_collectes.timestamp) = CURDATE()
 GROUP BY nom');
@@ -136,19 +109,6 @@ GROUP BY nom');
     element: 'graphm',
     data: [
 <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu de la table affectations
             $reponse = $bdd->query('SELECT type_dechets.couleur,type_dechets.nom, sum(vendus.quantite ) somme FROM type_dechets,vendus WHERE type_dechets.id = vendus.id_type_dechet AND DATE(vendus.timestamp) = CURDATE() AND vendus.prix > 0
 GROUP BY nom');
@@ -168,18 +128,6 @@ GROUP BY nom');
     labelColor: '#060',
     colors: [
 <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
  
             // On recupère tout le contenu de la table affectations
             $reponse = $bdd->query('SELECT type_dechets.couleur,type_dechets.nom, sum(vendus.quantite ) somme FROM type_dechets,vendus WHERE type_dechets.id = vendus.id_type_dechet AND DATE(vendus.timestamp) = CURDATE() AND vendus.prix > 0
@@ -204,19 +152,6 @@ GROUP BY nom');
     element: 'grapha',
     data: [
 <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu de la table affectations
             $reponse = $bdd->query('SELECT type_dechets.couleur,type_dechets.nom, sum(pesees_sorties.masse) somme 
 FROM type_dechets,pesees_sorties 
@@ -251,19 +186,6 @@ GROUP BY nom');
     labelColor: '#060',
     colors: [
 <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu de la table affectations
             $reponse = $bdd->query('SELECT type_dechets.couleur,type_dechets.nom, sum(pesees_sorties.masse) somme 
 FROM type_dechets,pesees_sorties 

--- a/ifaces/modification_convention_sortie.php
+++ b/ifaces/modification_convention_sortie.php
@@ -1,5 +1,7 @@
 <?php session_start(); 
 
+require_once('../moteur/dbconfig.php');
+
 //Vérification des autorisations de l'utilisateur et des variables de session requises pour l'affichage de cette page:
  if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($_SESSION['niveau'], 'j') !== false))
       { include "tete.php" ?>
@@ -8,24 +10,6 @@
          <div class="panel-heading">Modifier les données concernant le partenaire n° <?php echo $_POST['id']?>, <?php echo $_POST['nom']?>.  </div>
 <?php
 //on obtien la couleur de la localité dans la base
-
-
-
-
-
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
-            // Si tout va bien, on peut continuer
-            // On recupère tout le contenu de la table point de vente
-
 
 $req = $bdd->prepare("SELECT couleur FROM conventions_sorties WHERE id = :id ");
 $req->execute(array('id' => $_POST['id']));

--- a/ifaces/modification_filiere_sortie.php
+++ b/ifaces/modification_filiere_sortie.php
@@ -1,5 +1,7 @@
 <?php session_start(); 
 
+require_once('../moteur/dbconfig.php');
+
 //Vérification des autorisations de l'utilisateur et des variables de session requisent pour l'affichage de cette page:
     if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($_SESSION['niveau'], 'j') !== false))
       { include "tete.php" ?>
@@ -8,24 +10,6 @@
          <div class="panel-heading">Modifier les données concernant la filiere n° <?php echo $_POST['id']?>, <?php echo $_POST['nom']?>. </div>
 <?php
 //on obtient la couleur de la localité dans la base
-
-
-
-
-
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
-            // Si tout va bien, on peut continuer
-            // On recupère tout le contenu de la table point de vente
-
 
 $req = $bdd->prepare("SELECT couleur FROM filieres_sortie WHERE id = :id ");
 $req->execute(array('id' => $_POST['id']));
@@ -77,16 +61,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
 <label>Type de dechets enlevé:</label>
 <select name="id_dechet" id="id_dechet" class="form-control " required>
             <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
             // On affiche une liste deroulante des type de collecte visibles
             $reponse = $bdd->query('SELECT * FROM type_dechets_evac WHERE visible = "oui"');
             // On affiche chaque entree une à une

--- a/ifaces/modification_localites.php
+++ b/ifaces/modification_localites.php
@@ -1,5 +1,7 @@
 <?php session_start();
 
+require_once('../moteur/dbconfig.php');
+
 //Vérification des autorisations de l'utilisateur et des variables de session requisent pour l'affichage de cette page:
     if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($_SESSION['niveau'], 'k') !== false))
       { include "tete.php" ?>
@@ -8,24 +10,6 @@
          <div class="panel-heading">Modifier les données concernant la localité n° <?php echo $_POST['id']?>, <?php echo $_POST['nom']?>. </div>
 <?php
 //on obtien la couleur de la localité dans la base
-
-
-
-
-
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
-            // Si tout va bien, on peut continuer
-            // On recupère tout le contenu de la table point de vente
-
 
 $req = $bdd->prepare("SELECT couleur FROM localites WHERE id = :id ");
 $req->execute(array('id' => $_POST['id']));

--- a/ifaces/modification_moyens_paiement.php
+++ b/ifaces/modification_moyens_paiement.php
@@ -1,5 +1,7 @@
 <?php session_start(); 
 
+require_once('../moteur/dbconfig.php');
+
 //Vérification des autorisations de l'utilisateur et des variables de session requisent pour l'affichage de cette page:
     if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($_SESSION['niveau'], 'k') !== false))
       { include "tete.php" ?>
@@ -8,19 +10,6 @@
          <div class="panel-heading">Modifier les données concernant le moyen de paiments n° <?php echo $_POST['id']?>, <?php echo $_POST['nom']?>. </div>
 <?php
 //on obtien la couleur de la localité dans la base
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
-            // Si tout va bien, on peut continuer
-            // On recupère tout le contenu de la table point de vente
-
 
 $req = $bdd->prepare("SELECT couleur FROM moyens_paiement WHERE id = :id ");
 $req->execute(array('id' => $_POST['id']));

--- a/ifaces/modification_objet.php
+++ b/ifaces/modification_objet.php
@@ -1,5 +1,6 @@
 <?php session_start(); 
 
+
 //Vérification des autorisations de l'utilisateur et des variables de session requisent pour l'affichage de cette page:
    if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($_SESSION['niveau'], 'g') !== false))
       { include "tete.php" ?>

--- a/ifaces/modification_points_collecte.php
+++ b/ifaces/modification_points_collecte.php
@@ -1,5 +1,7 @@
 <?php session_start(); 
 
+require_once('../moteur/dbconfig.php');
+
 //Vérification des autorisations de l'utilisateur et des variables de session requisent pour l'affichage de cette page:
     if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($_SESSION['niveau'], 'k') !== false))
       { include "tete.php" ?>
@@ -17,24 +19,6 @@ else
 $id = $_GET['id'];
 }
 //on obtient la couleur de la localité dans la base
-
-
-
-
-
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
-            // Si tout va bien, on peut continuer
-            // On recupère tout le contenu de la table point de vente
-
 
 $req = $bdd->prepare("SELECT couleur FROM points_collecte WHERE id = :id ");
 $req->execute(array('id' => $id));

--- a/ifaces/modification_points_sortie.php
+++ b/ifaces/modification_points_sortie.php
@@ -1,5 +1,7 @@
 <?php session_start(); 
 
+require_once('../moteur/dbconfig.php');
+
 //Vérification des autorisations de l'utilisateur et des variables de session requisent pour l'affichage de cette page:
  if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($_SESSION['niveau'], 'k') !== false))
       { include "tete.php" ?>
@@ -17,24 +19,6 @@ else
 $id = $_GET['id'];
 }
 //on obtient la couleur de la localité dans la base
-
-
-
-
-
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
-            // Si tout va bien, on peut continuer
-            // On recupère tout le contenu de la table point de vente
-
 
 $req = $bdd->prepare("SELECT couleur FROM points_sortie WHERE id = :id ");
 $req->execute(array('id' => $id));

--- a/ifaces/modification_points_vente.php
+++ b/ifaces/modification_points_vente.php
@@ -1,5 +1,7 @@
 <?php session_start(); 
 
+require_once('../moteur/dbconfig.php');
+
 //Vérification des autorisations de l'utilisateur et des variables de session requises pour l'affichage de cette page:
     if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($_SESSION['niveau'], 'k') !== false))
       { include "tete.php" ?>
@@ -20,19 +22,6 @@ $id = $_GET['id'];
 
 
 
-
-
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
-            // Si tout va bien, on peut continuer
             // On recupère tout le contenu de la table point de vente
 
 

--- a/ifaces/modification_type_contenants.php
+++ b/ifaces/modification_type_contenants.php
@@ -1,5 +1,7 @@
 <?php session_start(); 
 
+require_once("../moteur/dbconfig.php");
+
 //Vérification des autorisations de l'utilisateur et des variables de session requises pour l'affichage de cette page:
     if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($_SESSION['niveau'], 'g') !== false))
       { include "tete.php" ?>
@@ -8,17 +10,6 @@
          <div class="panel-heading">Modifier les données concernant le moyen de manutention n° <?php echo $_POST['id']?>, <?php echo $_POST['nom']?>. </div>
 <?php
 //on obtien la couleur de la localité dans la base
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
-            // Si tout va bien, on peut continuer
             // On recupère tout le contenu de la table point de vente
 
 

--- a/ifaces/modification_type_poubelles.php
+++ b/ifaces/modification_type_poubelles.php
@@ -1,5 +1,7 @@
 <?php session_start(); 
 
+require_once("../moteur/dbconfig.php");
+
 //Vérification des autorisations de l'utilisateur et des variables de session requises pour l'affichage de cette page:
    if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($_SESSION['niveau'], 'g') !== false))
       { include "tete.php" ?>
@@ -8,17 +10,6 @@
          <div class="panel-heading">Modifier les données concernant le type de bac n° <?php echo $_POST['id']?>, <?php echo $_POST['nom']?>. </div>
 <?php
 //on obtient la couleur de la localité dans la base
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
-            // Si tout va bien, on peut continuer
             // On recupère tout le contenu de la table point de vente
 
 

--- a/ifaces/modification_types_collecte.php
+++ b/ifaces/modification_types_collecte.php
@@ -1,5 +1,7 @@
 <?php session_start(); 
 
+require_once("../moteur/dbconfig.php");
+
 //Vérification des autorisations de l'utilisateur et des variables de session requises pour l'affichage de cette page:
     if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($_SESSION['niveau'], 'k') !== false))
       { include "tete.php" ?>
@@ -8,18 +10,6 @@
          <div class="panel-heading">Modifier les données concernant le type de collecte n° <?php echo $_POST['id']?>, <?php echo $_POST['nom']?>. </div>
 <?php
 //on obtient la couleur de la localité dans la base
-
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
-            // Si tout va bien, on peut continuer
             // On recupère tout le contenu de la table point de vente
 
 

--- a/ifaces/modification_types_dechets.php
+++ b/ifaces/modification_types_dechets.php
@@ -1,5 +1,7 @@
 <?php session_start(); 
 
+require_once("../moteur/dbconfig.php");
+
 //Vérification des autorisations de l'utilisateur et des variables de session requises pour l'affichage de cette page:
     if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($_SESSION['niveau'], 'k') !== false))
       { include "tete.php" ?>
@@ -8,17 +10,6 @@
          <div class="panel-heading">Modifier les données concernant le type de dechets n° <?php echo $_POST['id']?>, <?php echo $_POST['nom']?>. </div>
 <?php
 //on obtien la couleur de la localité dans la base
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
-            // Si tout va bien, on peut continuer
             // On recupère tout le contenu de la table point de vente
 
 

--- a/ifaces/modification_types_dechets_evac.php
+++ b/ifaces/modification_types_dechets_evac.php
@@ -1,5 +1,7 @@
 <?php session_start(); 
 
+require_once("../moteur/dbconfig.php");
+
 //Vérification des autorisations de l'utilisateur et des variables de session requises pour l'affichage de cette page:
     if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($_SESSION['niveau'], 'k') !== false))
       { include "tete.php" ?>
@@ -8,17 +10,6 @@
          <div class="panel-heading">Modifier les données concernant le type de déchet sortant n° <?php echo $_POST['id']?>, <?php echo $_POST['nom']?>. </div>
 <?php
 //on obtient la couleur de la localité dans la base
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
-            // Si tout va bien, on peut continuer
             // On recupère tout le contenu de la table point de vente
 
 

--- a/ifaces/modification_types_sortie.php
+++ b/ifaces/modification_types_sortie.php
@@ -1,5 +1,7 @@
 <?php session_start(); 
 
+require_once("../moteur/dbconfig.php");
+
 //Vérification des autorisations de l'utilisateur et des variables de session requises pour l'affichage de cette page:
    if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($_SESSION['niveau'], 'k') !== false))
       { include "tete.php" ?>
@@ -13,17 +15,6 @@
 
 
 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
-            // Si tout va bien, on peut continuer
             // On recupère tout le contenu de la table point de sortie
 
 

--- a/ifaces/modification_verification_collecte.php
+++ b/ifaces/modification_verification_collecte.php
@@ -1,5 +1,7 @@
 <?php session_start();
 
+require_once("../moteur/dbconfig.php");
+
 //Vérification des autorisations de l'utilisateur et des variables de session requises pour l'affichage de cette page:
    if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($_SESSION['niveau'], 'h') !== false))
       {  include "tete.php" ?>
@@ -51,16 +53,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
 <label for="id_type_collecte">Type de collecte:</label>
 <select name="id_type_collecte" id="id_type_collecte" class="form-control " required>
             <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
             // On affiche une liste deroulante des type de collecte visibles
             $reponse = $bdd->query('SELECT * FROM type_collecte WHERE visible = "oui"');
             // On affiche chaque entree une à une
@@ -86,16 +78,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
     <label for="id_localite">Localisation:</label>
 <select name="id_localite" id="id_localite" class="form-control " required>
             <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
             // On affiche une liste deroulante des type de collecte visibles
             $reponse = $bdd->query('SELECT * FROM localites WHERE visible = "oui"');
             // On affiche chaque entree une à une
@@ -147,18 +129,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
         </thead>
         <tbody>
         <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
 /*
 'SELECT type_dechets.couleur,type_dechets.nom, sum(pesees_collectes.masse) somme 
 FROM type_dechets,pesees_collectes 
@@ -226,18 +196,6 @@ $req->execute(array('id_collecte' => $_GET['ncollecte']));
 
 
 <td><?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
 $req3 = $bdd->prepare('SELECT utilisateurs.mail mail
                        FROM utilisateurs, pesees_collectes
                        WHERE  pesees_collectes.id = :id_collecte 

--- a/ifaces/modification_verification_pesee.php
+++ b/ifaces/modification_verification_pesee.php
@@ -1,5 +1,7 @@
 <?php session_start(); 
 
+require_once("../moteur/dbconfig.php");
+
 //Vérification des autorisations de l'utilisateur et des variables de session requises pour l'affichage de cette page:
   if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($_SESSION['niveau'], 'h') !== false))
       {  include "tete.php" ?>
@@ -52,16 +54,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
 <label for="id_type_dechet">Type de dechet:</label>
 <select name="id_type_dechet" id="id_type_dechet" class="form-control " required>
             <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
             // On affiche une liste deroulante des type de collecte visibles
             $reponse = $bdd->query('SELECT * FROM type_dechets WHERE visible = "oui"');
             // On affiche chaque entree une à une

--- a/ifaces/modification_verification_pesee_sorties.php
+++ b/ifaces/modification_verification_pesee_sorties.php
@@ -1,5 +1,7 @@
 <?php session_start(); 
 
+require_once("../moteur/dbconfig.php");
+
 //Vérification des autorisations de l'utilisateur et des variables de session requises pour l'affichage de cette page:
   if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($_SESSION['niveau'], 'h') !== false))
       {  include "tete.php" ?>
@@ -54,16 +56,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
   <label for="id_type_dechet">Type d'objet:</label>
 <select name="id_type_dechet" id="id_type_dechet" class="form-control " required>
             <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
             // On affiche une liste deroulante des type de collecte visibles
             $reponse = $bdd->query('SELECT * FROM type_dechets');
             // On affiche chaque entree une à une
@@ -93,16 +85,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
   <label for="id_type_dechet">Dechets et materiaux:</label>
 <select name="id_type_dechet_evac" id="id_type_dechet_evac" class="form-control " required>
             <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
             // On affiche une liste deroulante des type de collecte visibles
             $reponse = $bdd->query('SELECT * FROM type_dechets_evac ');
             // On affiche chaque entree une à une

--- a/ifaces/modification_verification_pesee_sortiesc.php
+++ b/ifaces/modification_verification_pesee_sortiesc.php
@@ -1,5 +1,7 @@
 <?php session_start(); 
 
+require_once("../moteur/dbconfig.php");
+
 //Vérification des autorisations de l'utilisateur et des variables de session requises pour l'affichage de cette page:
   if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($_SESSION['niveau'], 'h') !== false))
       {  include "tete.php" ?>
@@ -54,16 +56,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
   <label for="id_type_dechet">Type d'objet:</label>
 <select name="id_type_dechet" id="id_type_dechet" class="form-control " required>
             <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
             // On affiche une liste deroulante des type de collecte visibles
             $reponse = $bdd->query('SELECT * FROM type_dechets ');
             // On affiche chaque entree une à une
@@ -93,16 +85,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
   <label for="id_type_dechet">Dechets et materiaux:</label>
 <select name="id_type_dechet_evac" id="id_type_dechet_evac" class="form-control " required>
             <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
             // On affiche une liste deroulante des type de collecte visibles
             $reponse = $bdd->query('SELECT * FROM type_dechets_evac ');
             // On affiche chaque entree une à une

--- a/ifaces/modification_verification_pesee_sortiesd.php
+++ b/ifaces/modification_verification_pesee_sortiesd.php
@@ -1,5 +1,7 @@
 <?php session_start(); 
 
+require_once("../moteur/dbconfig.php");
+
 //Vérification des autorisations de l'utilisateur et des variables de session requises pour l'affichage de cette page:
   if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($_SESSION['niveau'], 'h') !== false))
       {  include "tete.php" ?>
@@ -54,16 +56,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
   <label for="id_type_dechet">Type d'objet:</label>
 <select name="id_type_dechet" id="id_type_dechet" class="form-control " required>
             <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
             // On affiche une liste deroulante des type de collecte visibles
             $reponse = $bdd->query('SELECT * FROM type_dechets ');
             // On affiche chaque entree une à une
@@ -93,16 +85,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
   <label for="id_type_dechet">Dechets et materiaux:</label>
 <select name="id_type_dechet_evac" id="id_type_dechet_evac" class="form-control " required>
             <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
             // On affiche une liste deroulante des type de collecte visibles
             $reponse = $bdd->query('SELECT * FROM type_dechets_evac ');
             // On affiche chaque entree une à une

--- a/ifaces/modification_verification_pesee_sortiesp.php
+++ b/ifaces/modification_verification_pesee_sortiesp.php
@@ -1,5 +1,7 @@
 <?php session_start(); 
 
+require_once("../moteur/dbconfig.php");
+
 //Vérification des autorisations de l'utilisateur et des variables de session requises pour l'affichage de cette page:
   if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($_SESSION['niveau'], 'h') !== false))
       {  include "tete.php" ?>
@@ -56,16 +58,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
   <label for="id_type_poubelle">Type de poubelle:</label>
 <select name="id_type_poubelle" id="id_type_poubelle" class="form-control " required>
             <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
             // On affiche une liste deroulante des type de collecte visibles
             $reponse = $bdd->query('SELECT * FROM types_poubelles ');
             // On affiche chaque entree une à une

--- a/ifaces/modification_verification_remboursement.php
+++ b/ifaces/modification_verification_remboursement.php
@@ -1,5 +1,7 @@
 <?php session_start();
 
+require_once('../moteur/dbconfig.php');
+
 //Vérification des autorisations de l'utilisateur et des variables de session requises pour l'affichage de cette page:
    if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($_SESSION['niveau'], 'h') !== false))
       {  include "tete.php" ?>
@@ -62,16 +64,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
 
 
         <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
  
             // Si tout va bien, on peut continuer
 /*
@@ -143,18 +135,6 @@ $req->execute(array('id_vente' => $_GET['nvente']));
 
 
 <td><?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
 $req3 = $bdd->prepare('SELECT utilisateurs.mail mail
                        FROM utilisateurs, vendus
                        WHERE  vendus.id = :id_vendu 
@@ -177,18 +157,6 @@ $req3->execute(array('id_vendu' => $donnees['id']));
 
 
 <td><?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
 $req3 = $bdd->prepare('SELECT vendus.last_hero_timestamp lht
                        FROM  vendus
                        WHERE  vendus.id = :id_vendu 

--- a/ifaces/modification_verification_sorties.php
+++ b/ifaces/modification_verification_sorties.php
@@ -1,5 +1,7 @@
 <?php session_start(); 
 
+require_once('../moteur/dbconfig.php');
+
 //Vérification des autorisations de l'utilisateur et des variables de session requises pour l'affichage de cette page:
     if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($_SESSION['niveau'], 'h') !== false))
       {  include "tete.php" ?>
@@ -51,16 +53,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
 <label for="id_type_sortie">Type de sortie:</label>
 <select name="id_type_sortie" id="id_type_sortie" class="form-control " required>
             <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
             // On affiche une liste deroulante des type de sortie visibles
             $reponse = $bdd->query('SELECT * FROM type_sortie WHERE visible = "oui"');
             // On affiche chaque entree une à une
@@ -111,18 +103,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
         </thead>
         <tbody>
         <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
 /*
 'SELECT type_dechets.couleur,type_dechets.nom, sum(pesees_collectes.masse) somme 
 FROM type_dechets,pesees_collectes 
@@ -163,18 +143,6 @@ $req->execute(array('id_sortie' => $_GET['nsortie']));
 
 <td>
  <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-           
           
 $req3 = $bdd->prepare('SELECT utilisateurs.mail mail
                        FROM utilisateurs ,pesees_sorties
@@ -220,18 +188,6 @@ $req3->execute(array('id_sortie' => $_GET['nsortie']));
 </td>
 
 <td><?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-           
           
 $req5 = $bdd->prepare('SELECT utilisateurs.mail mail
                        FROM pesees_sorties, utilisateurs
@@ -253,18 +209,6 @@ $req5->execute(array('id_sortie' => $donnees['id']));
             
                 ?></td>
 <td><?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-           
           
 $req4 = $bdd->prepare('SELECT pesees_sorties.last_hero_timestamp lht
                        FROM pesees_sorties
@@ -299,18 +243,6 @@ $req4->execute(array('id_sortie' => $donnees['id']));
                 ?>
 
  <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
 /*
 'SELECT type_dechets.couleur,type_dechets.nom, sum(pesees_collectes.masse) somme 
 FROM type_dechets,pesees_collectes 
@@ -351,18 +283,6 @@ $req->execute(array('id_sortie' => $_GET['nsortie']));
 
 <td>
  <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-           
           
 $req3 = $bdd->prepare('SELECT utilisateurs.mail mail
                        FROM utilisateurs ,pesees_sorties
@@ -406,18 +326,6 @@ $req3->execute(array('id_sortie' => $_GET['nsortie']));
 </td>
 
 <td><?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-           
           
 $req5 = $bdd->prepare('SELECT utilisateurs.mail mail
                        FROM pesees_sorties, utilisateurs
@@ -439,18 +347,6 @@ $req5->execute(array('id_sortie' => $donnees['id']));
             
                 ?></td>
 <td><?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-           
           
 $req4 = $bdd->prepare('SELECT pesees_sorties.last_hero_timestamp lht
                        FROM pesees_sorties

--- a/ifaces/modification_verification_sortiesc.php
+++ b/ifaces/modification_verification_sortiesc.php
@@ -1,5 +1,7 @@
 <?php session_start(); 
 
+require_once('../moteur/dbconfig.php');
+
 //Vérification des autorisations de l'utilisateur et des variables de session requises pour l'affichage de cette page:
   if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($_SESSION['niveau'], 'h') !== false))
       {  include "tete.php" ?>
@@ -51,16 +53,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
 <label for="id_convention">Nom du partenaire:</label>
 <select name="id_convention" id="id_convention" class="form-control " required>
             <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
             // On affiche une liste deroulante des type de sortie visibles
             $reponse = $bdd->query('SELECT * FROM conventions_sorties WHERE visible = "oui"');
             // On affiche chaque entree une à une
@@ -111,18 +103,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
         </thead>
         <tbody>
         <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
 /*
 'SELECT type_dechets.couleur,type_dechets.nom, sum(pesees_collectes.masse) somme 
 FROM type_dechets,pesees_collectes 
@@ -163,18 +143,6 @@ $req->execute(array('id_sortie' => $_GET['nsortie']));
 
 <td>
  <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-           
           
 $req3 = $bdd->prepare('SELECT utilisateurs.mail mail
                        FROM utilisateurs ,pesees_sorties
@@ -220,18 +188,6 @@ $req3->execute(array('id_sortie' => $_GET['nsortie']));
 </td>
 
 <td><?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-           
           
 $req5 = $bdd->prepare('SELECT utilisateurs.mail mail
                        FROM pesees_sorties, utilisateurs
@@ -253,18 +209,6 @@ $req5->execute(array('id_sortie' => $donnees['id']));
             
                 ?></td>
 <td><?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-           
           
 $req4 = $bdd->prepare('SELECT pesees_sorties.last_hero_timestamp lht
                        FROM pesees_sorties
@@ -299,18 +243,6 @@ $req4->execute(array('id_sortie' => $donnees['id']));
                 ?>
 
  <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
 /*
 'SELECT type_dechets.couleur,type_dechets.nom, sum(pesees_collectes.masse) somme 
 FROM type_dechets,pesees_collectes 
@@ -351,18 +283,6 @@ $req->execute(array('id_sortie' => $_GET['nsortie']));
 
 <td>
  <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-           
           
 $req3 = $bdd->prepare('SELECT utilisateurs.mail mail
                        FROM utilisateurs ,pesees_sorties
@@ -406,18 +326,6 @@ $req3->execute(array('id_sortie' => $_GET['nsortie']));
 </td>
 
 <td><?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-           
           
 $req5 = $bdd->prepare('SELECT utilisateurs.mail mail
                        FROM pesees_sorties, utilisateurs
@@ -439,19 +347,6 @@ $req5->execute(array('id_sortie' => $donnees['id']));
             
                 ?></td>
 <td><?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-           
-          
 $req4 = $bdd->prepare('SELECT pesees_sorties.last_hero_timestamp lht
                        FROM pesees_sorties
                        WHERE  pesees_sorties.id = :id_sortie

--- a/ifaces/modification_verification_sortiesd.php
+++ b/ifaces/modification_verification_sortiesd.php
@@ -1,5 +1,7 @@
 <?php session_start(); 
 
+require_once('../moteur/dbconfig.php');
+
 //Vérification des autorisations de l'utilisateur et des variables de session requises pour l'affichage de cette page:
   if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($_SESSION['niveau'], 'h') !== false))
       {  include "tete.php" ?>
@@ -58,18 +60,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
         </thead>
         <tbody>
         <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
 /*
 'SELECT type_dechets.couleur,type_dechets.nom, sum(pesees_collectes.masse) somme 
 FROM type_dechets,pesees_collectes 
@@ -111,18 +101,6 @@ $req->execute(array('id_sortie' => $_GET['nsortie']));
 
 <td>
  <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-           
           
 $req3 = $bdd->prepare('SELECT utilisateurs.mail mail
                        FROM utilisateurs ,pesees_sorties
@@ -168,18 +146,6 @@ $req3->execute(array('id_sortie' => $_GET['nsortie']));
 </td>
 
 <td><?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-           
           
 $req5 = $bdd->prepare('SELECT utilisateurs.mail mail
                        FROM pesees_sorties, utilisateurs
@@ -201,18 +167,6 @@ $req5->execute(array('id_sortie' => $donnees['id']));
             
                 ?></td>
 <td><?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-           
           
 $req4 = $bdd->prepare('SELECT pesees_sorties.last_hero_timestamp lht
                        FROM pesees_sorties

--- a/ifaces/modification_verification_sortiesp.php
+++ b/ifaces/modification_verification_sortiesp.php
@@ -1,5 +1,7 @@
 <?php session_start(); 
 
+require_once('../moteur/dbconfig.php');
+
 //Vérification des autorisations de l'utilisateur et des variables de session requises pour l'affichage de cette page:
   if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($_SESSION['niveau'], 'h') !== false))
       {  include "tete.php" ?>
@@ -58,18 +60,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
         </thead>
         <tbody>
         <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
 /*
 'SELECT type_dechets.couleur,type_dechets.nom, sum(pesees_collectes.masse) somme 
 FROM type_dechets,pesees_collectes 
@@ -111,18 +101,6 @@ $req->execute(array('id_sortie' => $_GET['nsortie']));
 
 <td>
  <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-           
           
 $req3 = $bdd->prepare('SELECT utilisateurs.mail mail
                        FROM utilisateurs ,pesees_sorties
@@ -168,18 +146,6 @@ $req3->execute(array('id_sortie' => $_GET['nsortie']));
 </td>
 
 <td><?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-           
           
 $req5 = $bdd->prepare('SELECT utilisateurs.mail mail
                        FROM pesees_sorties, utilisateurs
@@ -201,19 +167,6 @@ $req5->execute(array('id_sortie' => $donnees['id']));
             
                 ?></td>
 <td><?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-           
-          
 $req4 = $bdd->prepare('SELECT pesees_sorties.last_hero_timestamp lht
                        FROM pesees_sorties
                        WHERE  pesees_sorties.id = :id_sortie

--- a/ifaces/modification_verification_sortiesr.php
+++ b/ifaces/modification_verification_sortiesr.php
@@ -1,5 +1,7 @@
 <?php session_start();
 
+require_once('../moteur/dbconfig.php');
+
 //Vérification des autorisations de l'utilisateur et des variables de session requises pour l'affichage de cette page:
  if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($_SESSION['niveau'], 'h') !== false))
       {  include "tete.php" ?>
@@ -51,16 +53,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
 <label for="id_filiere">Nom de l'entreprise de recyclage:</label>
 <select name="id_filiere" id="id_filiere" class="form-control " required>
             <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
             // On affiche une liste deroulante des type de sortie visibles
             $reponse = $bdd->query('SELECT * FROM filieres_sortie WHERE visible = "oui"');
             // On affiche chaque entree une à une
@@ -108,16 +100,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
         </thead>
         <tbody>
         <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
  
             // Si tout va bien, on peut continuer
 /*

--- a/ifaces/modification_verification_vente.php
+++ b/ifaces/modification_verification_vente.php
@@ -1,5 +1,7 @@
 <?php session_start();
 
+require_once('../moteur/dbconfig.php');
+
 //Vérification des autorisations de l'utilisateur et des variables de session requises pour l'affichage de cette page:
    if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($_SESSION['niveau'], 'h') !== false))
       {  include "tete.php" ?>
@@ -62,19 +64,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
 
 
         <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
-
           
 $req = $bdd->prepare('SELECT 
 vendus.id ,vendus.timestamp,
@@ -130,18 +119,6 @@ $req->execute(array('id_vente' => $_GET['nvente']));
 
 
 <td><?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
 $req3 = $bdd->prepare('SELECT utilisateurs.mail mail
                        FROM utilisateurs, vendus
                        WHERE  vendus.id = :id_vendu 
@@ -164,18 +141,6 @@ $req3->execute(array('id_vendu' => $donnees['id']));
 
 
 <td><?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
 $req3 = $bdd->prepare('SELECT vendus.last_hero_timestamp lht
                        FROM  vendus
                        WHERE  vendus.id = :id_vendu 

--- a/ifaces/moyens_paiment.php
+++ b/ifaces/moyens_paiment.php
@@ -1,5 +1,7 @@
 <?php session_start(); 
 
+require_once('../moteur/dbconfig.php');
+
 //Vérification des autorisations de l'utilisateur et des variables de session requises pour l'affichage de cette page:
   if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($_SESSION['niveau'], 'k') !== false))
       { include "tete.php" ?>
@@ -61,19 +63,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
         </thead>
         <tbody>
         <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu de la table affectations
             $reponse = $bdd->query('SELECT * FROM moyens_paiement');
  

--- a/ifaces/remboursement.php
+++ b/ifaces/remboursement.php
@@ -1,5 +1,7 @@
 <?php session_start(); 
 
+require_once('../moteur/dbconfig.php');
+
 //Vérification des autorisations de l'utilisateur et des variables de session requises pour l'affichage de cette page:
 if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($_SESSION['niveau'], 'v'.$_GET['numero']) !== false))
       {include "tete.php";?>
@@ -32,17 +34,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
       <legend>
              <?php 
           // on determine le numero de la vente
-        try
-            {
-            // On se connecte à MySQL 
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
          $req = $bdd->prepare("SELECT max(id) FROM ventes WHERE id_point_vente = :id ");
             $req->execute(array('id' => $_GET['numero']));
  
@@ -53,19 +44,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
            }
               $req->closeCursor(); // Termine le traitement de la requête
             //on affiche le nom du point de vente
-            try
-            {
-            // On se connecte à MySQL 
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu de la table point de collecte
           
             $req = $bdd->prepare("SELECT * FROM points_vente WHERE id = :id ");
@@ -190,16 +168,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
 
 
             <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
             // On recupère tout le contenu de la table point de collecte
             $reponse = $bdd->query('SELECT * FROM type_dechets WHERE visible = "oui"');
  
@@ -217,16 +185,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
 
 
   <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
              // On recupère tout le contenu de la table grille_objets
            $req = $bdd->prepare('SELECT * FROM grille_objets WHERE id_type_dechet = :id_type_dechet AND visible = "oui"   ');
            $req->execute(array('id_type_dechet' => $donnees['id']));

--- a/ifaces/sorties.php
+++ b/ifaces/sorties.php
@@ -1,5 +1,7 @@
 <?php session_start();
 
+require_once('../moteur/dbconfig.php');
+
 //Vérification des autorisations de l'utilisateur et des variables de session requises pour l'affichage de cette page: 
 if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($_SESSION['niveau'], 's'.$_GET['numero']) !== false))
       {include "tete.php";
@@ -15,16 +17,6 @@ if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($
 //
 
 //on obtient la masse maximum suportée par la balance à ce point de sortie dans la variable $pesee_max
-  try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
             //on obtient le nom du point de collecte designé par $GET['numero']
             $req = $bdd->prepare("SELECT pesee_max FROM points_collecte WHERE id = :id ");
             $req->execute(array('id' => $_GET['numero']));
@@ -48,16 +40,6 @@ function printdiv(divID)
       if (parseInt(document.getElementById('najout').value) >= 1) 
           { 
          var mtot =<?php 
-                      try
-                      {
-                      // On se connecte à MySQL
-                      include('../moteur/dbconfig.php');
-                      }
-                      catch(Exception $e)
-                      {
-                      // En cas d'erreur, on affiche un message et on arrête tout
-                      die('Erreur : '.$e->getMessage());
-                      }
                       // On obtient tous les visibles de la table type_dechets de manière à cacluler mtot...
                       $reponse = $bdd->query('SELECT * FROM type_dechets WHERE visible = "oui"' );
                       // On affiche chaque entrée une à une
@@ -67,16 +49,6 @@ function printdiv(divID)
                       }
                       $reponse->closeCursor(); // Termine le traitement de la requête
                       ?><?php 
-                      try
-                      {
-                      // On se connecte à MySQL
-                      include('../moteur/dbconfig.php');
-                      }
-                      catch(Exception $e)
-                      {
-                      // En cas d'erreur, on affiche un message et on arrête tout
-                      die('Erreur : '.$e->getMessage());
-                      }
                       // On obtient tous les visibles de la table type_dechets de manière à cacluler mtot...
                       $reponse = $bdd->query('SELECT * FROM type_dechets_evac WHERE visible = "oui"' );
                       // On affiche chaque entrée une à une
@@ -135,20 +107,6 @@ function tdechet_write(y,z)
 function tdechet_clear()
 {
 <?php 
-          
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu de la table point de collecte
             $reponse = $bdd->query('SELECT * FROM type_dechets WHERE visible = "oui"');
  
@@ -191,20 +149,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
           <fieldset>
        <legend>
         <?php 
-          
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu de la table point de collecte
           
             $req = $bdd->prepare("SELECT * FROM points_sortie WHERE id = :id ");
@@ -282,20 +226,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
 
 
 <?php 
-          
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu de la table point de collecte
             $reponse = $bdd->query('SELECT * FROM type_dechets WHERE visible = "oui"');
  
@@ -329,23 +259,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
               <?php }
 
               $reponse->closeCursor(); // Termine le traitement de la requête
-                ?>
-
-
-                <?php 
-          
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
  
             // On recupère tout le contenu de la table point de collecte
             $reponse = $bdd->query('SELECT * FROM type_dechets_evac WHERE visible = "oui"');
@@ -400,17 +313,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
  <label for="type_sortie">Types de sortie:</label>
           <select name ="type_sortie" id ="type_sortie" class="form-control" required autofocus>
 <?php         
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
-            // Si tout va bien, on peut continuer
             // On recupère tout le contenu de la table type de sortie
             $reponse = $bdd->query('SELECT * FROM type_sortie WHERE visible = "oui"');
            // On affiche chaque entree une à une
@@ -474,16 +376,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
         <ul class="dropdown-menu dropdown-menu-right" role="menu">
         
   <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
             // On affiche une liste déroulante des localités visibles
             $reponse = $bdd->query('SELECT * FROM type_contenants WHERE visible = "oui"');
             // On affiche chaque entrée une à une
@@ -558,16 +450,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
 
 
             <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
             // On recupère tout le contenu de la table point de collecte
             $reponse = $bdd->query('SELECT * FROM type_dechets WHERE visible = "oui"');
  
@@ -601,16 +483,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
 
 
             <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
             // On recupère tout le contenu de la table point de collecte
             $reponse = $bdd->query('SELECT * FROM type_dechets_evac WHERE visible = "oui"');
  

--- a/ifaces/sortiesc.php
+++ b/ifaces/sortiesc.php
@@ -1,5 +1,7 @@
 <?php session_start();
 
+require_once('../moteur/dbconfig.php');
+
 //Vérification des autorisations de l'utilisateur et des variables de session requises pour l'affichage de cette page: 
 if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($_SESSION['niveau'], 's'.$_GET['numero']) !== false))
       {include "tete.php";
@@ -13,16 +15,6 @@ if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($
 //
 //
         //on obtient la masse maximum suporté par la balance à ce point de sortie dans la variable $pesee_max
-  try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
             //on obtient le nom du point de collecte designé par $GET['numero']
             $req = $bdd->prepare("SELECT pesee_max FROM points_collecte WHERE id = :id ");
             $req->execute(array('id' => $_GET['numero']));
@@ -46,16 +38,6 @@ function printdiv(divID)
        if (parseInt(document.getElementById('najout').value) >= 1) 
           { 
 var mtot =<?php 
-                      try
-                      {
-                      // On se connecte à MySQL
-                      include('../moteur/dbconfig.php');
-                      }
-                      catch(Exception $e)
-                      {
-                      // En cas d'erreur, on affiche un message et on arrête tout
-                      die('Erreur : '.$e->getMessage());
-                      }
                       // On obtient tous les visibles de la table type_dechets de manière à cacluler mtot...
                       $reponse = $bdd->query('SELECT * FROM type_dechets WHERE visible = "oui"' );
                       // On affiche chaque entrée une à une
@@ -65,16 +47,6 @@ var mtot =<?php
                       }
                       $reponse->closeCursor(); // Termine le traitement de la requête
                       ?><?php 
-                      try
-                      {
-                      // On se connecte à MySQL
-                      include('../moteur/dbconfig.php');
-                      }
-                      catch(Exception $e)
-                      {
-                      // En cas d'erreur, on affiche un message et on arrête tout
-                      die('Erreur : '.$e->getMessage());
-                      }
                       // On obtient tous les visibles de la table type_dechets de manière à cacluler mtot...
                       $reponse = $bdd->query('SELECT * FROM type_dechets_evac WHERE visible = "oui"' );
                       // On affiche chaque entrée une à une
@@ -131,20 +103,6 @@ function tdechet_write(y,z)
 function tdechet_clear()
 {
 <?php 
-          
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu de la table point de collecte
             $reponse = $bdd->query('SELECT * FROM type_dechets WHERE visible ="oui"');
  
@@ -161,20 +119,6 @@ function tdechet_clear()
                 ?>  
 
                 <?php 
-          
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu de la table point de collecte
             $reponse = $bdd->query('SELECT * FROM type_dechets_evac WHERE visible ="oui"');
  
@@ -220,20 +164,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
           <fieldset>
        <legend>
         <?php 
-          
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu de la table point de collecte
           
             $req = $bdd->prepare("SELECT * FROM points_sortie WHERE id = :id ");
@@ -315,20 +245,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
 
 
 <?php 
-          
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu de la table point de collecte
             $reponse = $bdd->query('SELECT * FROM type_dechets WHERE visible = "oui"');
  
@@ -361,24 +277,7 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
               <?php }
 
               $reponse->closeCursor(); // Termine le traitement de la requête
-                ?>
-
-
-                <?php 
           
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu de la table point de collecte
             $reponse = $bdd->query('SELECT * FROM type_dechets_evac WHERE visible = "oui"');
  
@@ -434,20 +333,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
 
 
 <?php 
-          
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu de la table point de collecte
             $reponse = $bdd->query('SELECT * FROM conventions_sorties WHERE visible = "oui"');
  
@@ -514,16 +399,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
         <ul class="dropdown-menu dropdown-menu-right" role="menu">
         
   <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
             // On affiche une liste déroulante des localités visibles
             $reponse = $bdd->query('SELECT * FROM type_contenants WHERE visible = "oui"');
             // On affiche chaque entrée une à une
@@ -599,16 +474,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
 
 
             <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
             // On recupère tout le contenu de la table point de collecte
             $reponse = $bdd->query('SELECT * FROM type_dechets WHERE visible = "oui"');
  
@@ -642,16 +507,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
 
 
             <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
             // On recupère tout le contenu de la table point de collecte
             $reponse = $bdd->query('SELECT * FROM type_dechets_evac WHERE visible = "oui"');
  

--- a/ifaces/sortiesd.php
+++ b/ifaces/sortiesd.php
@@ -1,5 +1,7 @@
 <?php session_start(); 
 
+require_once('../moteur/dbconfig.php');
+
 //Vérification des autorisations de l'utilisateur et des variables de session requises pour l'affichage de cette page:
 if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($_SESSION['niveau'], 's'.$_GET['numero']) !== false))
       { include "tete.php";
@@ -14,16 +16,6 @@ if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($
 //
 //
         //on obtient la masse maximum suporté par la balance à ce point de sortie dans la variable $pesee_max
-  try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
             //on obtient le nom du point de collecte designé par $GET['numero']
             $req = $bdd->prepare("SELECT pesee_max FROM points_collecte WHERE id = :id ");
             $req->execute(array('id' => $_GET['numero']));
@@ -43,16 +35,6 @@ function printdiv(divID)
 
 
             var mtot =<?php 
-                      try
-                      {
-                      // On se connecte à MySQL
-                      include('../moteur/dbconfig.php');
-                      }
-                      catch(Exception $e)
-                      {
-                      // En cas d'erreur, on affiche un message et on arrête tout
-                      die('Erreur : '.$e->getMessage());
-                      }
                       // On obtient tous les visibles de la table type_dechets de manière à cacluler mtot...
                       $reponse = $bdd->query('SELECT * FROM type_dechets_evac WHERE visible = "oui"' );
                       // On affiche chaque entrée une à une
@@ -121,20 +103,6 @@ function tdechet_write(y,z)
 function tdechet_clear()
 {
 <?php 
-          
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu de la table point de collecte
             $reponse = $bdd->query('SELECT * FROM type_dechets_evac WHERE visible = "oui"');
  
@@ -177,20 +145,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
           <fieldset>
        <legend>
         <?php 
-          
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu de la table point de collecte
           
             $req = $bdd->prepare("SELECT * FROM points_sortie WHERE id = :id ");
@@ -274,20 +228,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
 
 
 <?php 
-          
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu de la table point de collecte
             $reponse = $bdd->query('SELECT * FROM type_dechets_evac WHERE visible = "oui"');
  
@@ -357,16 +297,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
         <ul class="dropdown-menu dropdown-menu-right" role="menu">
         
   <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
             // On affiche une liste déroulante des localités visibles
             $reponse = $bdd->query('SELECT * FROM type_contenants WHERE visible = "oui"');
             // On affiche chaque entrée une à une
@@ -442,16 +372,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
 
 
             <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
             // On recupère tout le contenu de la table point de collecte
             $reponse = $bdd->query('SELECT * FROM type_dechets_evac WHERE visible = "oui"');
  

--- a/ifaces/sortiesp.php
+++ b/ifaces/sortiesp.php
@@ -1,4 +1,6 @@
 <?php session_start(); 
+
+require_once('../moteur/dbconfig.php');
  
 //Vérification des autorisations de l'utilisateur et des variables de session requises pour l'affichage de cette page:
 if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($_SESSION['niveau'], 's'.$_GET['numero']) !== false))
@@ -13,16 +15,6 @@ if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($
 //
 //
         //on obtien la masse maximum suporté par la balance à ce point de sortie dans la variable $pesee_max
-  try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
             //on obtient le nom du point de collecte designé par $GET['numero']
             $req = $bdd->prepare("SELECT pesee_max FROM points_collecte WHERE id = :id ");
             $req->execute(array('id' => $_GET['numero']));
@@ -46,16 +38,6 @@ function printdiv(divID)
       if (parseInt(document.getElementById('najout').value) >= 1) 
           { 
       var mtot =<?php 
-                      try
-                      {
-                      // On se connecte à MySQL
-                      include('../moteur/dbconfig.php');
-                      }
-                      catch(Exception $e)
-                      {
-                      // En cas d'erreur, on affiche un message et on arrête tout
-                      die('Erreur : '.$e->getMessage());
-                      }
                       // On obtient tous les visibles de la table type_dechets de manière à cacluler mtot...
                       $reponse = $bdd->query('SELECT * FROM types_poubelles WHERE visible = "oui"' );
                       // On affiche chaque entrée une à une
@@ -109,19 +91,6 @@ function tdechet_clear()
 {
 <?php 
           
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu de la table types_poubelles
             $reponse = $bdd->query('SELECT * FROM types_poubelles');
  
@@ -165,19 +134,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
        <legend>
         <?php 
           
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu de la table points_sortie
           
             $req = $bdd->prepare("SELECT * FROM points_sortie WHERE id = :id ");
@@ -260,19 +216,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
 
 <?php 
           
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu de la table point de collecte
             $reponse = $bdd->query('SELECT * FROM types_poubelles WHERE visible = "oui"');
  
@@ -388,19 +331,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
           
            <?php 
           
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu de la table point de collecte
             $reponse = $bdd->query('SELECT * FROM types_poubelles WHERE visible = "oui" ');
  

--- a/ifaces/sortiesr.php
+++ b/ifaces/sortiesr.php
@@ -1,4 +1,6 @@
 <?php session_start(); 
+
+require_once('../moteur/dbconfig.php');
  
 //Vérification des autorisations de l'utilisateur et des variables de session requises pour l'affichage de cette page:
 if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($_SESSION['niveau'], 's'.$_GET['numero']) !== false))
@@ -13,16 +15,6 @@ if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($
 //
 //
         //on obtien la masse maximum suporté par la balance à ce point de sortie dans la variable $pesee_max
-  try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
             //on obtient le nom du point de collecte designé par $GET['numero']
             $req = $bdd->prepare("SELECT pesee_max FROM points_collecte WHERE id = :id ");
             $req->execute(array('id' => $_GET['numero']));
@@ -39,16 +31,6 @@ function printdiv(divID)
        if (parseInt(document.getElementById('najout').value) >= 1) 
           { 
       var mtot =<?php 
-                      try
-                      {
-                      // On se connecte à MySQL
-                      include('../moteur/dbconfig.php');
-                      }
-                      catch(Exception $e)
-                      {
-                      // En cas d'erreur, on affiche un message et on arrête tout
-                      die('Erreur : '.$e->getMessage());
-                      }
                       // On obtient tous les visibles de la table type_dechets de manière à cacluler mtot...
                       $reponse = $bdd->query('SELECT * FROM type_dechets_evac WHERE visible = "oui"' );
                       // On affiche chaque entrée une à une
@@ -147,19 +129,6 @@ function tdechet_clear()
     document.getElementById("number").value = "";
 <?php 
           
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu de la table point de collecte
             $reponse = $bdd->query('SELECT * FROM type_dechets_evac WHERE visible = "oui"');
  
@@ -221,19 +190,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
        <legend>
         <?php 
           
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu de la table point de collecte
           
             $req = $bdd->prepare("SELECT * FROM points_sortie WHERE id = :id ");
@@ -320,19 +276,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
 
 <?php 
           
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu de la table type dechets
             $reponse = $bdd->query('SELECT * FROM type_dechets_evac WHERE visible = "oui"');
  
@@ -390,19 +333,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
 
 <?php 
           
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu de la table point de collecte
             $reponse = $bdd->query('SELECT filieres_sortie.id ,filieres_sortie.nom , filieres_sortie.id_type_dechet_evac, type_dechets_evac.nom AS type_dechet
 
@@ -463,16 +393,6 @@ WHERE filieres_sortie.visible = "oui" AND filieres_sortie.id_type_dechet_evac = 
         <ul class="dropdown-menu dropdown-menu-right" role="menu">
         
   <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
             // On affiche une liste déroulante des localités visibles
             $reponse = $bdd->query('SELECT * FROM type_contenants WHERE visible = "oui"');
             // On affiche chaque entrée une à une

--- a/ifaces/tete.php
+++ b/ifaces/tete.php
@@ -34,6 +34,9 @@
  <ul class="nav navbar-nav">
   <?php
 //session_start(); déjà inclu dans chacun des fichiers appelant ce fichier
+
+require_once('../moteur/dbconfig.php');
+
     if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource")
       { ?> 
 <ul class="nav navbar-nav">
@@ -44,17 +47,6 @@
           <a href="#" class="dropdown-toggle" data-toggle="dropdown">Points de collecte<b class="caret"></b></a>
             <ul class="dropdown-menu">
             <li><?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
-            // Si tout va bien, on peut continuer
             // On recupère tout le contenu de la table point de vente
             $reponse = $bdd->query('SELECT * FROM points_collecte');
             // On affiche chaque entree une à une
@@ -81,17 +73,6 @@
           <a href="#" class="dropdown-toggle" data-toggle="dropdown">Sorties hors-boutique<b class="caret"></b></a>
             <ul class="dropdown-menu">
             <li><?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
-            // Si tout va bien, on peut continuer
             // On recupère tout le contenu de la table point de vente
             $reponse = $bdd->query('SELECT * FROM points_sortie');
             // On affiche chaque entree une à une
@@ -119,17 +100,6 @@
           <a href="#" class="dropdown-toggle" data-toggle="dropdown">Points de vente<b class="caret"></b></a>
             <ul class="dropdown-menu">
             <li><?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
-            // Si tout va bien, on peut continuer
             // On recupère tout le contenu de la table point de vente
             $reponse = $bdd->query('SELECT * FROM points_vente');
             // On affiche chaque entree une à une

--- a/ifaces/tete_vente.php
+++ b/ifaces/tete_vente.php
@@ -36,6 +36,9 @@
  <ul class="nav navbar-nav">
   <?php
 //session_start(); déjà inclu dans chacun des fichiers appelant ce fichier
+
+require_once('../moteur/dbconfig.php');
+
     if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource")
       { ?> 
 <ul class="nav navbar-nav">
@@ -46,17 +49,6 @@
           <a href="#" class="dropdown-toggle" data-toggle="dropdown">Points de collecte<b class="caret"></b></a>
             <ul class="dropdown-menu">
             <li><?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
-            // Si tout va bien, on peut continuer
             // On recupère tout le contenu de la table point de vente
             $reponse = $bdd->query('SELECT * FROM points_collecte');
             // On affiche chaque entree une à une
@@ -83,17 +75,6 @@
           <a href="#" class="dropdown-toggle" data-toggle="dropdown">Sorties hors-boutique<b class="caret"></b></a>
             <ul class="dropdown-menu">
             <li><?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
-            // Si tout va bien, on peut continuer
             // On recupère tout le contenu de la table point de vente
             $reponse = $bdd->query('SELECT * FROM points_sortie');
             // On affiche chaque entree une à une
@@ -121,17 +102,6 @@
           <a href="#" class="dropdown-toggle" data-toggle="dropdown">Points de vente<b class="caret"></b></a>
             <ul class="dropdown-menu">
             <li><?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
-            // Si tout va bien, on peut continuer
             // On recupère tout le contenu de la table point de vente
             $reponse = $bdd->query('SELECT * FROM points_vente');
             // On affiche chaque entree une à une

--- a/ifaces/types_collecte.php
+++ b/ifaces/types_collecte.php
@@ -1,5 +1,7 @@
 <?php session_start(); 
 
+require_once('../moteur/dbconfig.php');
+
 //Vérification des autorisations de l'utilisateur et des variables de session requises pour l'affichage de cette page:
   if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($_SESSION['niveau'], 'k') !== false))
       { include "tete.php" ?>
@@ -60,19 +62,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
         </thead>
         <tbody>
         <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu de la table affectations
             $reponse = $bdd->query('SELECT * FROM type_collecte');
  

--- a/ifaces/types_dechets.php
+++ b/ifaces/types_dechets.php
@@ -1,5 +1,7 @@
 <?php session_start(); 
 
+require_once('../moteur/dbconfig.php');
+
 //Vérification des autorisations de l'utilisateur et des variables de session requises pour l'affichage de cette page:
   if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($_SESSION['niveau'], 'k') !== false))
       { include "tete.php" ?>
@@ -61,19 +63,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
         </thead>
         <tbody>
         <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu de la table affectations
             $reponse = $bdd->query('SELECT * FROM type_dechets');
  

--- a/ifaces/types_dechets_evac.php
+++ b/ifaces/types_dechets_evac.php
@@ -1,5 +1,7 @@
 <?php session_start();
 
+require_once('../moteur/dbconfig.php');
+
 //Vérification des autorisations de l'utilisateur et des variables de session requises pour l'affichage de cette page:
   if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($_SESSION['niveau'], 'k') !== false))
       { include "tete.php" ?>
@@ -61,19 +63,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
         </thead>
         <tbody>
         <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu de la table affectations
             $reponse = $bdd->query('SELECT * FROM type_dechets_evac');
  

--- a/ifaces/utilisateurs.php
+++ b/ifaces/utilisateurs.php
@@ -1,5 +1,7 @@
 <?php session_start(); 
 
+require_once('../moteur/dbconfig.php');
+
 //Vérification des autorisations de l'utilisateur et des variables de session requises pour l'affichage de cette page:
 if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($_SESSION['niveau'], 'l') !== false))
       {  include "tete.php" ?>
@@ -58,17 +60,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
   </div>
 <div class="col-md-4"><div class="alert alert-info"><label for="niveauc">Points de collecte:</label><br>
 <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
-            // Si tout va bien, on peut continuer
             // On recupère tout le contenu de la table point de collecte
             $reponse = $bdd->query('SELECT * FROM points_collecte');
             // On affiche chaque entree une à une
@@ -84,17 +75,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
           
                                             <div class="alert alert-info"><label for="niveauv">Points de vente:</label><br>
           <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
-            // Si tout va bien, on peut continuer
             // On recupère tout le contenu de la table point de vente
             $reponse = $bdd->query('SELECT * FROM points_vente');
             // On affiche chaque entree une à une
@@ -114,17 +94,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
                  ?></div>
                                             <div class="alert alert-info"><label for="niveaus">Points de sortie hors-boutique:</label><br>
           <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
-            // Si tout va bien, on peut continuer
             // On recupère tout le contenu de la table point de vente
             $reponse = $bdd->query('SELECT * FROM points_sortie');
             // On affiche chaque entree une à une

--- a/ifaces/ventes.php
+++ b/ifaces/ventes.php
@@ -1,4 +1,7 @@
 <?php session_start(); 
+
+require_once('../moteur/dbconfig.php');
+
 //Vérification des autorisations de l'utilisateur et des variables de session requises pour l'affichage de cette page:
 if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($_SESSION['niveau'], 'v'.$_GET['numero']) !== false))
       {include "tete_vente.php";?>
@@ -11,17 +14,6 @@ if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($
       <legend>
         <?php 
           // on determine le numero de la vente
-        try
-            {
-            // On se connecte à MySQL 
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
          $req = $bdd->prepare("SELECT max(id) FROM ventes WHERE id_point_vente = :id ");
             $req->execute(array('id' => $_GET['numero']));
  
@@ -32,19 +24,6 @@ if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($
            }
               $req->closeCursor(); // Termine le traitement de la requête
             //on affiche le nom du point de vente
-            try
-            {
-            // On se connecte à MySQL 
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu de la table point de collecte
           
             $req = $bdd->prepare("SELECT * FROM points_vente WHERE id = :id ");
@@ -210,16 +189,6 @@ $('input[name="my-checkbox"]').on('switchChange.bootstrapSwitch', function(event
 
 
             <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
             // On recupère tout le contenu de la table point de collecte
             $reponse = $bdd->query('SELECT * FROM type_dechets WHERE visible = "oui"');
  
@@ -237,16 +206,6 @@ $('input[name="my-checkbox"]').on('switchChange.bootstrapSwitch', function(event
 
 
   <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
              // On recupère tout le contenu de la table grille_objets
            $req = $bdd->prepare('SELECT * FROM grille_objets WHERE id_type_dechet = :id_type_dechet AND visible = "oui"  ORDER BY nom ');
            $req->execute(array('id_type_dechet' => $donnees['id']));
@@ -284,16 +243,6 @@ $('input[name="my-checkbox"]').on('switchChange.bootstrapSwitch', function(event
 <div class="btn-group" data-toggle="buttons">
 
  <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
             // On recupère tout le contenu de la table point de collecte
             $reponse = $bdd->query('SELECT * FROM moyens_paiement WHERE visible = "oui"');
  
@@ -399,16 +348,6 @@ $('input[name="my-checkbox"]').on('switchChange.bootstrapSwitch', function(event
 function rembou() {
   var code_soumis = prompt('Veuillez renseigner le code de remboursement');
 var codi = <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
             // On recupère tout le contenu de la table point de collecte
             $reponse = $bdd->query('SELECT cr FROM `description_structure`');
  

--- a/ifaces/verif_collecte.php
+++ b/ifaces/verif_collecte.php
@@ -1,4 +1,8 @@
-<?php session_start(); ?>
+<?php session_start(); 
+
+require_once('../moteur/dbconfig.php');
+
+?>
 <head>
       
       <link href="../css/bootstrap.min.css" rel="stylesheet">
@@ -47,19 +51,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
 
  <?php 
           //on affiche un onglet par type d'objet
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu des visibles de la table type_dechets
             $reponse = $bdd->query('SELECT * FROM points_collecte');
  
@@ -197,21 +188,6 @@ $time_fin = $time_fin." 23:59:59";
 </div>
 
 <?php
-try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
-
-
- 
             // On recupère toute la liste des filieres de sortie
             //   $reponse = $bdd->query('SELECT * FROM grille_objets');
           
@@ -251,18 +227,6 @@ if($donnees['nid'] > 0){ $req->closeCursor();
         </thead>
         <tbody>
         <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
 /*
 'SELECT type_dechets.couleur,type_dechets.nom, sum(pesees_collectes.masse) somme 
 FROM type_dechets,pesees_collectes 
@@ -300,18 +264,6 @@ $req->execute(array('id_point_collecte' => $_GET['numero'], 'du' => $time_debut,
             <td style="height:20px"> 
 
  <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
 $req2 = $bdd->prepare('SELECT SUM(pesees_collectes.masse) masse
                        FROM pesees_collectes
                        WHERE  pesees_collectes.id_collecte = :id_collecte ');
@@ -362,18 +314,6 @@ $req2->execute(array('id_collecte' => $donnees['id']));
 <td>
 
 <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
 $req3 = $bdd->prepare('SELECT utilisateurs.mail mail
                        FROM utilisateurs, collectes
                        WHERE  collectes.id = :id_collecte 

--- a/ifaces/verif_sorties.php
+++ b/ifaces/verif_sorties.php
@@ -1,4 +1,7 @@
-<?php session_start();?>
+<?php session_start();
+
+require_once('../moteur/dbconfig.php');
+?>
 <head>
       
       <link href="../css/bootstrap.min.css" rel="stylesheet">
@@ -52,18 +55,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
 
  <?php 
           //on affiche un onglet par type d'objet
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
  
             // On recupère tout le contenu des visibles de la table points_sortie
             $reponse = $bdd->query('SELECT * FROM points_sortie');
@@ -204,21 +195,6 @@ $time_fin = $time_fin." 23:59:59";
 
 </div>
 <?php
-try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
-
-
- 
             // On recupère toute la liste des filieres de sortie
             //   $reponse = $bdd->query('SELECT * FROM grille_objets');
           
@@ -261,18 +237,6 @@ if($donnees['nid'] > 0){ $req->closeCursor();
         </thead>
         <tbody>
         <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
           
 $req = $bdd->prepare('SELECT sorties.id,sorties.timestamp ,type_sortie.nom,sorties.adherent ,sorties.classe classe 
                        FROM sorties ,type_sortie
@@ -294,16 +258,6 @@ $req->execute(array('id_point_sortie' => $_GET['numero'], 'du' => $time_debut,'a
            <td> 
 
  <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
  
            
           
@@ -334,18 +288,6 @@ $req2->execute(array('id_sortie' => $donnees['id']));
 
 <td>
  <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-           
           
 $req3 = $bdd->prepare('SELECT utilisateurs.mail mail
                        FROM utilisateurs ,sorties
@@ -388,18 +330,6 @@ $req3->execute(array('id_sortie' => $donnees['id']));
 </td>
 
 <td><?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-           
           
 $req5 = $bdd->prepare('SELECT utilisateurs.mail mail
                        FROM sorties, utilisateurs
@@ -421,16 +351,6 @@ $req5->execute(array('id_sortie' => $donnees['id']));
             
                 ?></td>
 <td><?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
  
            
           
@@ -476,20 +396,6 @@ $req4->execute(array('id_sortie' => $donnees['id']));
 }
 ?>
 <?php
-try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
-
-
  
             // On recupère toute la liste des filieres de sortie
             //   $reponse = $bdd->query('SELECT * FROM grille_objets');
@@ -533,17 +439,6 @@ if($donnees['nid'] > 0){ $req->closeCursor();
         </thead>
         <tbody>
         <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
           
 $req = $bdd->prepare('SELECT sorties.id,sorties.timestamp ,conventions_sorties.nom,sorties.adherent , sorties.classe classe
                        FROM sorties ,conventions_sorties
@@ -564,17 +459,6 @@ $req->execute(array('id_point_sortie' => $_GET['numero'], 'du' => $time_debut,'a
            <td> 
 
  <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
            
           
 $req2 = $bdd->prepare('SELECT SUM(pesees_sorties.masse) masse
@@ -605,17 +489,6 @@ $req2->execute(array('id_sortie' => $donnees['id']));
 
 <td>
  <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
            
           
 $req3 = $bdd->prepare('SELECT utilisateurs.mail mail
@@ -654,17 +527,6 @@ $req3->execute(array('id_sortie' => $donnees['id']));
 </form>
 
 <td><?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
            
           
 $req5 = $bdd->prepare('SELECT utilisateurs.mail mail
@@ -687,18 +549,6 @@ $req5->execute(array('id_sortie' => $donnees['id']));
             
                 ?></td>
 <td><?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-           
           
 $req4 = $bdd->prepare('SELECT sorties.last_hero_timestamp lht
                        FROM sorties
@@ -746,20 +596,6 @@ $req4->execute(array('id_sortie' => $donnees['id']));
 }
 ?>
 <?php
-try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
-
-
  
             // On recupère toute la liste des filieres de sortie
             //   $reponse = $bdd->query('SELECT * FROM grille_objets');
@@ -802,18 +638,6 @@ if($donnees['nid'] > 0){ $req->closeCursor();
         </thead>
         <tbody>
         <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-           
           
 $req = $bdd->prepare('SELECT sorties.id,sorties.timestamp ,filieres_sortie.nom , sorties.classe classe
                        FROM sorties ,filieres_sortie
@@ -834,18 +658,6 @@ $req->execute(array('id_point_sortie' => $_GET['numero'], 'du' => $time_debut,'a
            <td> 
 
  <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            
           
 $req2 = $bdd->prepare('SELECT SUM(pesees_sorties.masse) masse
                        FROM pesees_sorties
@@ -874,18 +686,6 @@ $req2->execute(array('id_sortie' => $donnees['id']));
 
 <td>
  <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-           
           
 $req3 = $bdd->prepare('SELECT utilisateurs.mail mail
                        FROM utilisateurs ,sorties
@@ -924,18 +724,6 @@ $req3->execute(array('id_sortie' => $donnees['id']));
 </form>
 
 <td><?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-           
           
 $req5 = $bdd->prepare('SELECT utilisateurs.mail mail
                        FROM sorties, utilisateurs
@@ -957,16 +745,6 @@ $req5->execute(array('id_sortie' => $donnees['id']));
             
                 ?></td>
 <td><?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
  
            
           
@@ -1013,21 +791,6 @@ $req4->execute(array('id_sortie' => $donnees['id']));
 }
 ?>
 <?php
-try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
-
-
- 
             // On recupère toute la liste des filieres de sortie
             //   $reponse = $bdd->query('SELECT * FROM grille_objets');
           
@@ -1070,17 +833,6 @@ if($donnees['nid'] > 0){ $req->closeCursor();
         </thead>
         <tbody>
         <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
             
           
 $req = $bdd->prepare('SELECT sorties.id,sorties.timestamp , sorties.classe classe
@@ -1102,16 +854,6 @@ $req->execute(array('id_point_sortie' => $_GET['numero'], 'du' => $time_debut,'a
            <td> 
 
  <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
  
            
           
@@ -1142,19 +884,6 @@ $req2->execute(array('id_sortie' => $donnees['id']));
 
 <td>
  <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-           
-          
 $req3 = $bdd->prepare('SELECT utilisateurs.mail mail
                        FROM utilisateurs ,sorties
                        WHERE  sorties.id = :id_sortie
@@ -1193,18 +922,6 @@ $req3->execute(array('id_sortie' => $donnees['id']));
 </td>
 
 <td><?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-           
           
 $req5 = $bdd->prepare('SELECT utilisateurs.mail mail
                        FROM sorties, utilisateurs
@@ -1226,19 +943,6 @@ $req5->execute(array('id_sortie' => $donnees['id']));
             
                 ?></td>
 <td><?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-           
-          
 $req4 = $bdd->prepare('SELECT sorties.last_hero_timestamp lht
                        FROM sorties
                        WHERE  sorties.id = :id_sortie
@@ -1286,20 +990,6 @@ $req4->execute(array('id_sortie' => $donnees['id']));
 
 
 <?php
-try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
-
-
  
             // On recupère toute la liste des filieres de sortie
             //   $reponse = $bdd->query('SELECT * FROM grille_objets');
@@ -1343,17 +1033,6 @@ if($donnees['nid'] > 0){ $req->closeCursor();
         </thead>
         <tbody>
         <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
           
 $req = $bdd->prepare('SELECT sorties.id,sorties.timestamp ,sorties.adherent , sorties.classe classe
                        FROM sorties ,conventions_sorties
@@ -1376,17 +1055,6 @@ $req->execute(array('id_point_sortie' => $_GET['numero'], 'du' => $time_debut,'a
            <td> 
 
  <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
            
           
 $req2 = $bdd->prepare('SELECT SUM(pesees_sorties.masse) masse
@@ -1417,18 +1085,6 @@ $req2->execute(array('id_sortie' => $donnees['id']));
 
 <td>
  <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-           
           
 $req3 = $bdd->prepare('SELECT utilisateurs.mail mail
                        FROM utilisateurs ,sorties
@@ -1466,18 +1122,6 @@ $req3->execute(array('id_sortie' => $donnees['id']));
 </form>
 
 <td><?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-           
           
 $req5 = $bdd->prepare('SELECT utilisateurs.mail mail
                        FROM sorties, utilisateurs
@@ -1499,16 +1143,6 @@ $req5->execute(array('id_sortie' => $donnees['id']));
             
                 ?></td>
 <td><?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
  
            
           

--- a/ifaces/verif_vente.php
+++ b/ifaces/verif_vente.php
@@ -1,4 +1,8 @@
-<?php session_start();?>
+<?php session_start();
+
+require_once('../moteur/dbconfig.php');
+
+?>
 <head>
       
       <link href="../css/bootstrap.min.css" rel="stylesheet">
@@ -47,19 +51,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
 
  <?php 
           //on affiche un onglet par type d'objet
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
- 
             // On recupère tout le contenu des visibles de la table type_dechets
             $reponse = $bdd->query('SELECT * FROM points_vente');
  
@@ -223,18 +214,6 @@ $time_fin = $time_fin." 23:59:59";
         </thead>
         <tbody>
         <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
 /*
 'SELECT type_dechets.couleur,type_dechets.nom, sum(pesees_collectes.masse) somme 
 FROM type_dechets,pesees_collectes 
@@ -266,16 +245,6 @@ $req->execute(array('id_point_vente' => $_GET['numero'], 'du' => $time_debut,'au
 
 
             <td> <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
  
             // Si tout va bien, on peut continuer
 $req2 = $bdd->prepare('SELECT SUM(vendus.prix*vendus.quantite) pto
@@ -300,16 +269,6 @@ $rembo = 'non';
             
                 ?></td>
             <td><?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
  
             // Si tout va bien, on peut continuer
 $req3 = $bdd->prepare('SELECT SUM(vendus.remboursement*vendus.quantite) pto
@@ -334,18 +293,6 @@ $rembo = 'oui';
             
                 ?></td>
             <td><?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
 $req4 = $bdd->prepare('SELECT SUM(vendus.quantite) pto
                        FROM vendus
                        WHERE  vendus.id_vente = :id_vente 
@@ -371,16 +318,6 @@ $req4->execute(array('id_vente' => $donnees['id']));
             <td> <span class="badge" style="background-color:<?php echo$donnees['coul']?>"><?php echo $donnees['moyen']?></span></td>
             <td style="width:100px"><?php echo $donnees['commentaire']?></td>
             <td><?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
  
             // Si tout va bien, on peut continuer
 $req5 = $bdd->prepare('SELECT utilisateurs.mail mail
@@ -440,16 +377,6 @@ echo $donnees4['pto'];
 
             </td>
             <td><?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
  
             // Si tout va bien, on peut continuer
 $req5 = $bdd->prepare('SELECT utilisateurs.mail mail

--- a/ifaces/viz_caisse.php
+++ b/ifaces/viz_caisse.php
@@ -75,18 +75,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
         <tbody>
         <?php 
         $offset = intval($_SESSION['nb_viz_caisse']);
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
 /*
 'SELECT type_dechets.couleur,type_dechets.nom, sum(pesees_collectes.masse) somme 
 FROM type_dechets,pesees_collectes 
@@ -122,18 +110,6 @@ $req->execute();
 
 
             <td> <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
 $req2 = $bdd->prepare('SELECT SUM(vendus.prix*vendus.quantite) pto
                        FROM vendus
                        WHERE  vendus.id_vente = :id_vente 
@@ -156,18 +132,6 @@ $rembo = 'non';
             
                 ?></td>
             <td><?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
 $req3 = $bdd->prepare('SELECT SUM(vendus.remboursement*vendus.quantite) pto
                        FROM vendus
                        WHERE  vendus.id_vente = :id_vente 
@@ -190,18 +154,6 @@ $rembo = 'oui';
             
                 ?></td>
             <td><?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
 $req4 = $bdd->prepare('SELECT SUM(vendus.quantite) pto
                        FROM vendus
                        WHERE  vendus.id_vente = :id_vente 
@@ -227,18 +179,6 @@ $req4->execute(array('id_vente' => $donnees['id']));
             <td> <span class="badge" style="background-color:<?php echo$donnees['coul']?>"><?php echo $donnees['moyen']?></span></td>
             <td style="width:100px"><?php echo $donnees['commentaire']?></td>
             <td><?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
 $req5 = $bdd->prepare('SELECT utilisateurs.mail mail
                        FROM utilisateurs, ventes
                        WHERE  ventes.id = :id_vente 

--- a/ifaces/viz_remboursement.php
+++ b/ifaces/viz_remboursement.php
@@ -1,5 +1,7 @@
 <?php session_start();
 
+require_once('../moteur/dbconfig.php');
+
 //Vérification des autorisations de l'utilisateur et des variables de session requises pour l'affichage de cette page:
    if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($_SESSION['niveau'], 'h') !== false))
       {  include "tete.php" ?>
@@ -63,18 +65,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
 
 
         <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
 /*
 'SELECT type_dechets.couleur,type_dechets.nom, sum(pesees_collectes.masse) somme 
 FROM type_dechets,pesees_collectes 

--- a/ifaces/viz_vente.php
+++ b/ifaces/viz_vente.php
@@ -1,5 +1,7 @@
 <?php session_start();
 
+require_once('../moteur/dbconfig.php');
+
 //Vérification des autorisations de l'utilisateur et des variables de session requises pour l'affichage de cette page:
    if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND $_SESSION['viz_caisse'] = "oui" AND (strpos($_SESSION['niveau'], 'v'.$_GET['numero']) !== false)  )
       {  include "tete.php" ?>
@@ -63,19 +65,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
 
 
         <?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
-
           
 $req = $bdd->prepare('SELECT 
 vendus.id ,vendus.timestamp,
@@ -118,18 +107,6 @@ $req->execute(array('id_vente' => $_GET['nvente']));
 
 
 <td><?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
 $req3 = $bdd->prepare('SELECT utilisateurs.mail mail
                        FROM utilisateurs, vendus
                        WHERE  vendus.id = :id_vendu 
@@ -152,18 +129,6 @@ $req3->execute(array('id_vendu' => $donnees['id']));
 
 
 <td><?php 
-            try
-            {
-            // On se connecte à MySQL
-            include('../moteur/dbconfig.php');
-            }
-            catch(Exception $e)
-            {
-            // En cas d'erreur, on affiche un message et on arrête tout
-            die('Erreur : '.$e->getMessage());
-            }
- 
-            // Si tout va bien, on peut continuer
 $req3 = $bdd->prepare('SELECT vendus.last_hero_timestamp lht
                        FROM  vendus
                        WHERE  vendus.id = :id_vendu 


### PR DESCRIPTION

Attention cette modif supprime envrion 3000 lignes de code mais ce n'est pas méchant :-) 

En fait la sequence "try ... include ... catch " qui est utilisée un peu partout n'est pas nécessaire du tout pour plusieurs raisons: 

1- Il suffit d'ouvrir le connexion à la base une seule fois par page. l'objet $bdd est persitant et global. Pas besoin d'en recréer un à chaque fois.

2- Le test try /catch n'apporte rien dans ce cas précis. En fait si l'ouverture de la connexion échoue c'est même pas la peine d'aller plus loin. On arrête tout et basta.

Du coup un simple require_once en tête de fichier suffit et ça permet d'alleger le code....