### PR TITLE
déplacement du try/catch dans le fichier dbconfig

### DIFF
--- a/moteur/dbconfig.php.exemple
+++ b/moteur/dbconfig.php.exemple
@@ -1,3 +1,16 @@
 <?php
-$bdd = new PDO('mysql:host=localhost;dbname=oressource', 'oressource', 'mot_de_passe_a_changer');
+
+$host='localhost';
+$base='oressource';
+$user='oressource';
+$pass='mot_de_passe_a_changer';
+
+
+// NE RIEN MODIFIER APRES CETTE LIGNE
+try {
+	$bdd = new PDO("mysql:host=$host;dbname=$base", $user, $pass);
+} catch (PDOException $e) {
+        die('Connexion échouée : ' . $e->getMessage());
+}
+
 ?>


### PR DESCRIPTION

Meilleur gestion du try/catch au lieu de la faire sur chaque page, on le fait une fois pour toute dans le fichier de conf