### PR TITLE
Centralisation de l'affichage des erreurs et des messages

### DIFF
--- a/ifaces/collecte.php
+++ b/ifaces/collecte.php
@@ -152,28 +152,6 @@ function encaisse() {
                       ?>  
           }
 </script>
-<?php
-if ($_GET['err'] == "") // SI on a pas de message d'erreur
-{
-   echo'';
-}
-
-else // SINON 
-{
-  echo'<div class="alert alert-danger">'.$_GET['err'].'</div>';
-}
-
-
-if ($_GET['msg'] == "") // SI on a pas de message positif
-{
-   echo '';
-}
-
-else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
-{
-  echo'<div class="alert alert-success alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>'.$_GET['msg'].'</div>';
-}
-?>
 <br>
      
        <legend>

--- a/ifaces/edition_conventions_sortie.php
+++ b/ifaces/edition_conventions_sortie.php
@@ -13,28 +13,6 @@
         <h1>Gestion des conventions avec les partenaires</h1> 
          <div class="panel-heading">Gérez ici la liste de vos partenaires de réemploi.</div>
          <p>Permet de différencier les partenaires au moment de la mise en bilan </p>
-<?php
-if ($_GET['err'] == "") // SI on a pas de message d'erreur
-{
-   echo'';
-}
-
-else // SINON 
-{
-  echo'<div class="alert alert-danger">'.$_GET['err'].'</div>';
-}
-
-
-if ($_GET['msg'] == "") // SI on a pas de message positif
-{
-   echo '';
-}
-
-else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
-{
-  echo'<div class="alert alert-success alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>'.$_GET['msg'].'</div>';
-}
-?>
       <div class="panel-body">
         <div class="row">
         	<form action="../moteur/convention_sortie_post.php" method="post">

--- a/ifaces/edition_description.php
+++ b/ifaces/edition_description.php
@@ -30,22 +30,6 @@
             // On affiche chaque entree une à une
             while ($donnees = $reponse->fetch())
            {
-           if ($_GET['err'] == "") // SI on a pas de message d'erreur
-           {
-           echo'';
-           }
-           else // SINON 
-           {
-           echo'<div class="alert alert-danger">'.$_GET['err'].'</div>';
-           }
-           if ($_GET['msg'] == "") // SI on a pas de message positif
-           {
-           echo '';
-           }
-           else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
-           {
-           echo'<div class="alert alert-success alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>'.$_GET['msg'].'</div>';
-           }
            ?>
   <div class="panel-body">
     <div class="row">

--- a/ifaces/edition_filieres_sortie.php
+++ b/ifaces/edition_filieres_sortie.php
@@ -11,28 +11,6 @@
          <div class="panel-heading">Gérez ici la liste de ceux de vos partenaires qui traitent vos sorties destinées au recyclage.</div>
          <p>Permet notamment de différencier les "sorties recyclage" des "sorties ré-emploi" au moment de la mise en bilan.</p>
 
-<?php
-if ($_GET['err'] == "") // SI on a pas de message d'erreur
-{
-   echo'';
-}
-
-else // SINON 
-{
-  echo'<div class="alert alert-danger">'.$_GET['err'].'</div>';
-}
-
-
-if ($_GET['msg'] == "") // SI on a pas de message positif
-{
-   echo '';
-}
-
-else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
-{
-  echo'<div class="alert alert-success alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>'.$_GET['msg'].'</div>';
-}
-?>
       <div class="panel-body">
         <div class="row">
         	<form action="../moteur/filiere_sortie_post.php" method="post">

--- a/ifaces/edition_localites.php
+++ b/ifaces/edition_localites.php
@@ -8,28 +8,6 @@
 <h1>Gestion des localités de collecte</h1> 
   <div class="panel-heading">Définissez ici les localité d'origine possibles pour les matériaux entrant.</div>
   <p>Ces localités sont renseignées au moment de la collecte et permettent d'estimer l'impact territorial de la structure </p>
-                <?php
-                if ($_GET['err'] == "") // SI on a pas de message d'erreur
-                {
-                   echo'';
-                }
-
-                else // SINON 
-                {
-                  echo'<div class="alert alert-danger">'.$_GET['err'].'</div>';
-                }
-
-
-                if ($_GET['msg'] == "") // SI on a pas de message positif
-                {
-                   echo '';
-                }
-
-                else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
-                {
-                  echo'<div class="alert alert-success alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>'.$_GET['msg'].'</div>';
-                }
-                ?>
 <div class="panel-body">
   <div class="row">
  	<form action="../moteur/edition_localites_post.php" method="post">

--- a/ifaces/edition_mdp_admin.php
+++ b/ifaces/edition_mdp_admin.php
@@ -7,24 +7,6 @@
 <h1>Édition du mot de passe de l'utilisateur n°:<?php echo $_GET['id']?>, <?php echo $_GET['mail']?></h1> 
 <p>L'identifiant de cet utilisateur est son adresse E-mail: <?php echo $_GET['mail']?>, elle lui est demandée à chaque connexion à Oressource.</p>
 <br>     
-                    <?php
-                    if ($_GET['err'] == "") // SI on a pas de message d'erreur
-                    {
-                       echo'';
-                    }
-                    else // SINON 
-                    {
-                      echo'<div class="alert alert-danger">'.$_GET['err'].'</div>';
-                    }
-                    if ($_GET['msg'] == "") // SI on a pas de message positif
-                    {
-                       echo '';
-                    }
-                    else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
-                    {
-                      echo'<div class="alert alert-success alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>'.$_GET['msg'].'</div>';
-                    }
-                    ?>
 <div class="panel-body">
   <div class="row">
   <form action="../moteur/edition_mdp_admin_post.php" method="post">

--- a/ifaces/edition_mdp_utilisateur.php
+++ b/ifaces/edition_mdp_utilisateur.php
@@ -8,24 +8,6 @@
 <h1>Édition de votre mot de passe:</h1> 
 <p>Votre E-mail est: <?php echo $_SESSION['mail'] ?>, il vous est demandé au login.</p>
 <br>     
-                    <?php
-                    if ($_GET['err'] == "") // SI on a pas de message d'erreur
-                    {
-                       echo'';
-                    }
-                    else // SINON 
-                    {
-                      echo'<div class="alert alert-danger">'.$_GET['err'].'</div>';
-                    }
-                    if ($_GET['msg'] == "") // SI on a pas de message positif
-                    {
-                       echo '';
-                    }
-                    else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
-                    {
-                      echo'<div class="alert alert-success alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>'.$_GET['msg'].'</div>';
-                    }
-                    ?>
 <div class="panel-body">
   <div class="row">
   <form action="../moteur/edition_mdp_utilisateur_post.php" method="post">

--- a/ifaces/edition_points_collecte.php
+++ b/ifaces/edition_points_collecte.php
@@ -8,24 +8,6 @@
 <div class="container">
 <h1>Gestion des points de collecte</h1> 
   <div class="panel-heading">Gérez ici les différents points de collecte.</div>
-                    <?php
-                    if ($_GET['err'] == "") // SI on a pas de message d'erreur
-                    {
-                       echo'';
-                    }
-                    else // SINON 
-                    {
-                      echo'<div class="alert alert-danger">'.$_GET['err'].'</div>';
-                    }
-                    if ($_GET['msg'] == "") // SI on a pas de message positif
-                    {
-                       echo '';
-                    }
-                    else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
-                    {
-                      echo'<div class="alert alert-success alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>'.$_GET['msg'].'</div>';
-                    }
-                    ?>
   <div class="panel-body">
     <div class="row">
      	<form action="../moteur/edition_points_collecte_post.php" method="post">

--- a/ifaces/edition_points_sorties.php
+++ b/ifaces/edition_points_sorties.php
@@ -7,24 +7,6 @@
 <div class="container">
 <h1>Gestion des points de sortie hors-boutique</h1> 
   <div class="panel-heading">Gérez ici les différents points de sortie hors-boutique.</div>
-                        <?php
-                        if ($_GET['err'] == "") // SI on a pas de message d'erreur
-                        {
-                           echo'';
-                        }
-                        else // SINON 
-                        {
-                          echo'<div class="alert alert-danger">'.$_GET['err'].'</div>';
-                        }
-                        if ($_GET['msg'] == "") // SI on a pas de message positif
-                        {
-                           echo '';
-                        }
-                        else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
-                        {
-                          echo'<div class="alert alert-success alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>'.$_GET['msg'].'</div>';
-                        }
-                        ?>
 <div class="panel-body">
   <div class="row">
     <form action="../moteur/edition_points_sortie_post.php" method="post">

--- a/ifaces/edition_points_vente.php
+++ b/ifaces/edition_points_vente.php
@@ -6,29 +6,6 @@
     <div class="container">
         <h1>Gestion des points de vente</h1> 
          <div class="panel-heading">Gérez ici les différents points de vente.</div>
-<?php
-if ($_GET['err'] == "") // SI on a pas de message d'erreur
-{
-   echo'';
-}
-
-else // SINON 
-{
-  echo'<div class="alert alert-danger">'.$_GET['err'].'</div>';
-}
-
-
-if ($_GET['msg'] == "") // SI on a pas de message positif
-{
-   echo '';
-}
-
-else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
-{
-  echo'<div class="alert alert-success alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>'.$_GET['msg'].'</div>';
-}
-?>
-
       <div class="panel-body">
         <div class="row">
           <form action="../moteur/edition_points_vente_post.php" method="post">

--- a/ifaces/edition_types_contenants.php
+++ b/ifaces/edition_types_contenants.php
@@ -7,29 +7,6 @@
         <h1>Gestion de la typologie des bacs et des outils de manutention. </h1> 
          <div class="panel-heading">Renseignez ici la masse de vos bacs et outils de manutention .</div>
          <p>Cet outil vous permet notamment d'indiquer le poids de vos bacs, chariots, diables, etc. de manière à pouvoir le soustraire automatiquement au moment de la pesée.</p>
-<?php
-if ($_GET['err'] == "") // SI on a pas de message d'erreur
-{
-   echo'';
-}
-
-else // SINON 
-{
-  echo'<div class="alert alert-danger">'.$_GET['err'].'</div>';
-}
-
-
-if ($_GET['msg'] == "") // SI on a pas de message positif
-{
-   echo '';
-}
-
-else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
-{
-  echo'<div class="alert alert-success alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>'.$_GET['msg'].'</div>';
- 
-}
-?>
       <div class="panel-body">
         <div class="row">
         	<form action="../moteur/type_contenants_post.php" method="post">

--- a/ifaces/edition_types_poubelles.php
+++ b/ifaces/edition_types_poubelles.php
@@ -7,29 +7,6 @@
         <h1>Gestion de la typologie et de la masse des différentes poubelles mises à disposition de la structure par la ville</h1> 
          <div class="panel-heading">Gérez ici la liste de vos bacs à déchets.</div>
          <p>Cet outil vous permet notamment de discerner les bacs de matières recyclables de ceux dont le contenu est destiné à un enfouissement ou une incinération.</p>
-<?php
-if ($_GET['err'] == "") // SI on a pas de message d'erreur
-{
-   echo'';
-}
-
-else // SINON 
-{
-  echo'<div class="alert alert-danger">'.$_GET['err'].'</div>';
-}
-
-
-if ($_GET['msg'] == "") // SI on a pas de message positif
-{
-   echo '';
-}
-
-else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
-{
-  echo'<div class="alert alert-success alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>'.$_GET['msg'].'</div>';
- 
-}
-?>
       <div class="panel-body">
         <div class="row">
         	<form action="../moteur/type_poubelles_post.php" method="post">

--- a/ifaces/edition_types_sortie.php
+++ b/ifaces/edition_types_sortie.php
@@ -7,28 +7,6 @@
         <h1>Gestion de la typologie des sorties hors-boutique</h1> 
          <div class="panel-heading">Gérez ici les différents types de sorties hors-boutique.</div>
          <p>Permet de différencier les différentes destinations des dons (don a un particulier , une association, lié à une convention,...) </p>
-<?php
-if ($_GET['err'] == "") // SI on a pas de message d'erreur
-{
-   echo'';
-}
-
-else // SINON 
-{
-  echo'<div class="alert alert-danger">'.$_GET['err'].'</div>';
-}
-
-
-if ($_GET['msg'] == "") // SI on a pas de message positif
-{
-   echo '';
-}
-
-else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
-{
-  echo'<div class="alert alert-success alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>'.$_GET['msg'].'</div>';
-}
-?>
       <div class="panel-body">
         <div class="row">
 <form action="../moteur/types_sortie_post.php" method="post">

--- a/ifaces/edition_utilisateur.php
+++ b/ifaces/edition_utilisateur.php
@@ -11,28 +11,6 @@
          
          
     <br>     
-<?php
-if ($_GET['err'] == "") // SI on a pas de message d'erreur
-{
-   echo'';
-}
-
-else // SINON 
-{
-  echo'<div class="alert alert-danger">'.$_GET['err'].'</div>';
-}
-
-
-if ($_GET['msg'] == "") // SI on a pas de message positif
-{
-   echo '';
-}
-
-else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
-{
-  echo'<div class="alert alert-success alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>'.$_GET['msg'].'</div>';
-}
-?>
 <div class="panel-body">
         <div class="row">
             <form action="../moteur/modification_utilisateur_post.php" method="post">

--- a/ifaces/edition_utilisateurs.php
+++ b/ifaces/edition_utilisateurs.php
@@ -12,36 +12,6 @@
   
 </ul>
     <br>     
-<?php
-if ($_GET['err'] == "") // SI on a pas de message d'erreur
-{
-   echo'';
-}
-
-else // SINON 
-{
-  echo'<div class="alert alert-danger">'.$_GET['err'].'</div>';
-}
-
-
-if ($_GET['msg'] == "") // SI on a pas de message positif
-{
-   echo '';
-}
-
-else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
-{
-  echo'<div class="alert alert-success alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>'.$_GET['msg'].'</div>';
-}
-?>
-
-
-
-
-
-
-
-
       
       <!-- Table -->
       <table class="table">

--- a/ifaces/grilles_prix.php
+++ b/ifaces/grilles_prix.php
@@ -5,28 +5,6 @@
       {  include "tete.php" ?>
    <div class="container">
         <h1>Grille des prix</h1> 
-        <?php
-if ($_GET['err'] == "") // SI on a pas de message d'erreur
-{
-   echo'';
-}
-
-else // SINON 
-{
-  echo'<div class="alert alert-danger">'.$_GET['err'].'</div>';
-}
-
-
-if ($_GET['msg'] == "") // SI on a pas de message positif
-{
-   echo '';
-}
-
-else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
-{
-  echo'<div class="alert alert-success alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>'.$_GET['msg'].'</div>';
-}
-?>
  <div class="panel-body">
 <ul class="nav nav-tabs">
 

--- a/ifaces/login.php
+++ b/ifaces/login.php
@@ -2,24 +2,6 @@
 <br>
 <div class="container">
 <div class="starter-template">
-        <?php
-if ($_GET['err'] == "") // SI on a pas de message d'erreur
-{
-   echo'';
-}
-else // SINON 
-{
-  echo'<div class="alert alert-danger">'.$_GET['err'].'</div>';
-}
-if ($_GET['msg'] == "") // SI on a pas de message positif
-{
-   echo '';
-}
-else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
-{
-  echo'<div class="alert alert-success alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>'.$_GET['msg'].'</div>';
-}
-?>
 <br>
         <h1>Veuillez vous identifier:</h1>
 <br>

--- a/ifaces/modification_convention_sortie.php
+++ b/ifaces/modification_convention_sortie.php
@@ -36,27 +36,6 @@ $couleur = $donnees['couleur'];
               $reponse->closeCursor(); // Termine le traitement de la requête
                
 
-
-if ($_GET['err'] == "") // SI on a pas de message d'erreur
-{
-   echo'';
-}
-
-else // SINON 
-{
-  echo'<div class="alert alert-danger">'.$_GET['err'].'</div>';
-}
-
-
-if ($_GET['msg'] == "") // SI on a pas de message positif
-{
-   echo '';
-}
-
-else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
-{
-  echo'<div class="alert alert-success alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>'.$_GET['msg'].'</div>';
-}
 ?>
 
 

--- a/ifaces/modification_filiere_sortie.php
+++ b/ifaces/modification_filiere_sortie.php
@@ -37,26 +37,6 @@ $couleur = $donnees['couleur'];
                
 
 
-if ($_GET['err'] == "") // SI on a pas de message d'erreur
-{
-   echo'';
-}
-
-else // SINON 
-{
-  echo'<div class="alert alert-danger">'.$_GET['err'].'</div>';
-}
-
-
-if ($_GET['msg'] == "") // SI on a pas de message positif
-{
-   echo '';
-}
-
-else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
-{
-  echo'<div class="alert alert-success alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>'.$_GET['msg'].'</div>';
-}
 ?>
 
 

--- a/ifaces/modification_localites.php
+++ b/ifaces/modification_localites.php
@@ -36,27 +36,6 @@ $couleur = $donnees['couleur'];
               $reponse->closeCursor(); // Termine le traitement de la requête
                
 
-
-if ($_GET['err'] == "") // SI on a pas de message d'erreur
-{
-   echo'';
-}
-
-else // SINON 
-{
-  echo'<div class="alert alert-danger">'.$_GET['err'].'</div>';
-}
-
-
-if ($_GET['msg'] == "") // SI on a pas de message positif
-{
-   echo '';
-}
-
-else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
-{
-  echo'<div class="alert alert-success alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>'.$_GET['msg'].'</div>';
-}
 ?>
 
 

--- a/ifaces/modification_moyens_paiement.php
+++ b/ifaces/modification_moyens_paiement.php
@@ -32,26 +32,6 @@ $couleur = $donnees['couleur'];
                
 
 
-if ($_GET['err'] == "") // SI on a pas de message d'erreur
-{
-   echo'';
-}
-
-else // SINON 
-{
-  echo'<div class="alert alert-danger">'.$_GET['err'].'</div>';
-}
-
-
-if ($_GET['msg'] == "") // SI on a pas de message positif
-{
-   echo '';
-}
-
-else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
-{
-  echo'<div class="alert alert-success alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>'.$_GET['msg'].'</div>';
-}
 ?>
 
 

--- a/ifaces/modification_objet.php
+++ b/ifaces/modification_objet.php
@@ -6,31 +6,6 @@
     <div class="container">
         <h1>Grille des prix</h1> 
          <div class="panel-heading">Modifier les données concernant l'objet n° <?php echo $_POST['id']?>, <?php echo $_POST['nom']?>. </div>
-<?php
-
-if ($_GET['err'] == "") // SI on a pas de message d'erreur
-{
-   echo'';
-}
-
-else // SINON 
-{
-  echo'<div class="alert alert-danger">'.$_GET['err'].'</div>';
-}
-
-
-if ($_GET['msg'] == "") // SI on a pas de message positif
-{
-   echo '';
-}
-
-else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
-{
-  echo'<div class="alert alert-success alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>'.$_GET['msg'].'</div>';
-}
-?>
-
-
 
 
 

--- a/ifaces/modification_points_collecte.php
+++ b/ifaces/modification_points_collecte.php
@@ -45,27 +45,6 @@ $couleur = $donnees['couleur'];
               $reponse->closeCursor(); // Termine le traitement de la requête
                
 
-
-if ($_GET['err'] == "") // SI on a pas de message d'erreur
-{
-   echo'';
-}
-
-else // SINON 
-{
-  echo'<div class="alert alert-danger">'.$_GET['err'].'</div>';
-}
-
-
-if ($_GET['msg'] == "") // SI on a pas de message positif
-{
-   echo '';
-}
-
-else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
-{
-  echo'<div class="alert alert-success alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>'.$_GET['msg'].'</div>';
-}
 ?>
 
 

--- a/ifaces/modification_points_sortie.php
+++ b/ifaces/modification_points_sortie.php
@@ -45,27 +45,6 @@ $couleur = $donnees['couleur'];
               $reponse->closeCursor(); // Termine le traitement de la requête
                
 
-
-if ($_GET['err'] == "") // SI on a pas de message d'erreur
-{
-   echo'';
-}
-
-else // SINON 
-{
-  echo'<div class="alert alert-danger">'.$_GET['err'].'</div>';
-}
-
-
-if ($_GET['msg'] == "") // SI on a pas de message positif
-{
-   echo '';
-}
-
-else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
-{
-  echo'<div class="alert alert-success alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>'.$_GET['msg'].'</div>';
-}
 ?>
 
 

--- a/ifaces/modification_points_vente.php
+++ b/ifaces/modification_points_vente.php
@@ -45,27 +45,6 @@ $couleur = $donnees['couleur'];
               $reponse->closeCursor(); // Termine le traitement de la requête
                
 
-
-if ($_GET['err'] == "") // SI on a pas de message d'erreur
-{
-   echo'';
-}
-
-else // SINON 
-{
-  echo'<div class="alert alert-danger">'.$_GET['err'].'</div>';
-}
-
-
-if ($_GET['msg'] == "") // SI on a pas de message positif
-{
-   echo '';
-}
-
-else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
-{
-  echo'<div class="alert alert-success alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>'.$_GET['msg'].'</div>';
-}
 ?>
       <div class="panel-body">
         <div class="row">

--- a/ifaces/modification_type_contenants.php
+++ b/ifaces/modification_type_contenants.php
@@ -29,29 +29,8 @@ $donnees = $req->fetch();
 $couleur = $donnees['couleur'];
             
               $reponse->closeCursor(); // Termine le traitement de la requête
-               
 
 
-if ($_GET['err'] == "") // SI on a pas de message d'erreur
-{
-   echo'';
-}
-
-else // SINON 
-{
-  echo'<div class="alert alert-danger">'.$_GET['err'].'</div>';
-}
-
-
-if ($_GET['msg'] == "") // SI on a pas de message positif
-{
-   echo '';
-}
-
-else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
-{
-  echo'<div class="alert alert-success alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>'.$_GET['msg'].'</div>';
-}
 ?>
 
 

--- a/ifaces/modification_type_poubelles.php
+++ b/ifaces/modification_type_poubelles.php
@@ -31,27 +31,6 @@ $couleur = $donnees['couleur'];
               $reponse->closeCursor(); // Termine le traitement de la requête
                
 
-
-if ($_GET['err'] == "") // SI on a pas de message d'erreur
-{
-   echo'';
-}
-
-else // SINON 
-{
-  echo'<div class="alert alert-danger">'.$_GET['err'].'</div>';
-}
-
-
-if ($_GET['msg'] == "") // SI on a pas de message positif
-{
-   echo '';
-}
-
-else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
-{
-  echo'<div class="alert alert-success alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>'.$_GET['msg'].'</div>';
-}
 ?>
 
 

--- a/ifaces/modification_types_collecte.php
+++ b/ifaces/modification_types_collecte.php
@@ -33,26 +33,6 @@ $couleur = $donnees['couleur'];
                
 
 
-if ($_GET['err'] == "") // SI on a pas de message d'erreur
-{
-   echo'';
-}
-
-else // SINON 
-{
-  echo'<div class="alert alert-danger">'.$_GET['err'].'</div>';
-}
-
-
-if ($_GET['msg'] == "") // SI on a pas de message positif
-{
-   echo '';
-}
-
-else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
-{
-  echo'<div class="alert alert-success alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>'.$_GET['msg'].'</div>';
-}
 ?>
 
       <div class="panel-body">

--- a/ifaces/modification_types_dechets.php
+++ b/ifaces/modification_types_dechets.php
@@ -32,26 +32,6 @@ $couleur = $donnees['couleur'];
                
 
 
-if ($_GET['err'] == "") // SI on a pas de message d'erreur
-{
-   echo'';
-}
-
-else // SINON 
-{
-  echo'<div class="alert alert-danger">'.$_GET['err'].'</div>';
-}
-
-
-if ($_GET['msg'] == "") // SI on a pas de message positif
-{
-   echo '';
-}
-
-else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
-{
-  echo'<div class="alert alert-success alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>'.$_GET['msg'].'</div>';
-}
 ?>
 
 

--- a/ifaces/modification_types_dechets_evac.php
+++ b/ifaces/modification_types_dechets_evac.php
@@ -32,26 +32,6 @@ $couleur = $donnees['couleur'];
                
 
 
-if ($_GET['err'] == "") // SI on a pas de message d'erreur
-{
-   echo'';
-}
-
-else // SINON 
-{
-  echo'<div class="alert alert-danger">'.$_GET['err'].'</div>';
-}
-
-
-if ($_GET['msg'] == "") // SI on a pas de message positif
-{
-   echo '';
-}
-
-else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
-{
-  echo'<div class="alert alert-success alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>'.$_GET['msg'].'</div>';
-}
 ?>
 
 

--- a/ifaces/modification_types_sortie.php
+++ b/ifaces/modification_types_sortie.php
@@ -36,27 +36,6 @@ $couleur = $donnees['couleur'];
               $reponse->closeCursor(); // Termine le traitement de la requête
                
 
-
-if ($_GET['err'] == "") // SI on a pas de message d'erreur
-{
-   echo'';
-}
-
-else // SINON 
-{
-  echo'<div class="alert alert-danger">'.$_GET['err'].'</div>';
-}
-
-
-if ($_GET['msg'] == "") // SI on a pas de message positif
-{
-   echo '';
-}
-
-else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
-{
-  echo'<div class="alert alert-success alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>'.$_GET['msg'].'</div>';
-}
 ?>
 
 

--- a/ifaces/modification_verification_collecte.php
+++ b/ifaces/modification_verification_collecte.php
@@ -5,28 +5,6 @@
       {  include "tete.php" ?>
    <div class="container">
         <h1>Modifier la collecte n° <?php echo $_GET['ncollecte']?></h1> 
-        <?php
-if ($_GET['err'] == "") // SI on a pas de message d'erreur
-{
-   echo'';
-}
-
-else // SINON 
-{
-  echo'<div class="alert alert-danger">'.$_GET['err'].'</div>';
-}
-
-
-if ($_GET['msg'] == "") // SI on a pas de message positif
-{
-   echo '';
-}
-
-else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
-{
-  echo'<div class="alert alert-success alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>'.$_GET['msg'].'</div>';
-}
-?>
  <div class="panel-body">
 
 

--- a/ifaces/modification_verification_objet.php
+++ b/ifaces/modification_verification_objet.php
@@ -5,28 +5,6 @@
       {  include "tete.php" ?>
    <div class="container">
         <h1>Modifier l'objet vendu n° <?php echo $_POST['id']?> appartenant à la vente <?php echo $_POST['nvente']?> </h1> 
-        <?php
-if ($_GET['err'] == "") // SI on a pas de message d'erreur
-{
-   echo'';
-}
-
-else // SINON 
-{
-  echo'<div class="alert alert-danger">'.$_GET['err'].'</div>';
-}
-
-
-if ($_GET['msg'] == "") // SI on a pas de message positif
-{
-   echo '';
-}
-
-else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
-{
-  echo'<div class="alert alert-success alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>'.$_GET['msg'].'</div>';
-}
-?>
  <div class="panel-body">
 
 

--- a/ifaces/modification_verification_objet_remboursement.php
+++ b/ifaces/modification_verification_objet_remboursement.php
@@ -5,28 +5,6 @@
       {  include "tete.php" ?>
    <div class="container">
         <h1>Modifier l'objet remboursé n° <?php echo $_POST['id']?> appartenant au remboursement n° <?php echo $_POST['nvente']?> </h1> 
-        <?php
-if ($_GET['err'] == "") // SI on a pas de message d'erreur
-{
-   echo'';
-}
-
-else // SINON 
-{
-  echo'<div class="alert alert-danger">'.$_GET['err'].'</div>';
-}
-
-
-if ($_GET['msg'] == "") // SI on a pas de message positif
-{
-   echo '';
-}
-
-else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
-{
-  echo'<div class="alert alert-success alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>'.$_GET['msg'].'</div>';
-}
-?>
  <div class="panel-body">
 
 

--- a/ifaces/modification_verification_pesee.php
+++ b/ifaces/modification_verification_pesee.php
@@ -5,28 +5,6 @@
       {  include "tete.php" ?>
    <div class="container">
         <h1>Modifier la pesée n° <?php echo $_POST['id']?> appartenant à la collecte <?php echo $_POST['ncollecte']?> </h1> 
-        <?php
-if ($_GET['err'] == "") // SI on a pas de message d'erreur
-{
-   echo'';
-}
-
-else // SINON 
-{
-  echo'<div class="alert alert-danger">'.$_GET['err'].'</div>';
-}
-
-
-if ($_GET['msg'] == "") // SI on a pas de message positif
-{
-   echo '';
-}
-
-else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
-{
-  echo'<div class="alert alert-success alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>'.$_GET['msg'].'</div>';
-}
-?>
  <div class="panel-body">
 
 

--- a/ifaces/modification_verification_pesee_sorties.php
+++ b/ifaces/modification_verification_pesee_sorties.php
@@ -5,28 +5,6 @@
       {  include "tete.php" ?>
    <div class="container">
         <h1>Modifier la pesée n° <?php echo $_POST['id']?> appartenant à la sortie <?php echo $_POST['nsortie']?> </h1> 
-        <?php
-if ($_GET['err'] == "") // SI on a pas de message d'erreur
-{
-   echo'';
-}
-
-else // SINON 
-{
-  echo'<div class="alert alert-danger">'.$_GET['err'].'</div>';
-}
-
-
-if ($_GET['msg'] == "") // SI on a pas de message positif
-{
-   echo '';
-}
-
-else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
-{
-  echo'<div class="alert alert-success alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>'.$_GET['msg'].'</div>';
-}
-?>
  <div class="panel-body">
 
 

--- a/ifaces/modification_verification_pesee_sortiesc.php
+++ b/ifaces/modification_verification_pesee_sortiesc.php
@@ -5,28 +5,6 @@
       {  include "tete.php" ?>
    <div class="container">
         <h1>Modifier la pesée n° <?php echo $_POST['id']?> appartenant à la sortie <?php echo $_POST['nsortie']?> </h1> 
-        <?php
-if ($_GET['err'] == "") // SI on a pas de message d'erreur
-{
-   echo'';
-}
-
-else // SINON 
-{
-  echo'<div class="alert alert-danger">'.$_GET['err'].'</div>';
-}
-
-
-if ($_GET['msg'] == "") // SI on a pas de message positif
-{
-   echo '';
-}
-
-else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
-{
-  echo'<div class="alert alert-success alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>'.$_GET['msg'].'</div>';
-}
-?>
  <div class="panel-body">
 
 

--- a/ifaces/modification_verification_pesee_sortiesd.php
+++ b/ifaces/modification_verification_pesee_sortiesd.php
@@ -5,28 +5,6 @@
       {  include "tete.php" ?>
    <div class="container">
         <h1>Modifier la pesée n° <?php echo $_POST['id']?> appartenant à la sortie <?php echo $_POST['nsortie']?> </h1> 
-        <?php
-if ($_GET['err'] == "") // SI on a pas de message d'erreur
-{
-   echo'';
-}
-
-else // SINON 
-{
-  echo'<div class="alert alert-danger">'.$_GET['err'].'</div>';
-}
-
-
-if ($_GET['msg'] == "") // SI on a pas de message positif
-{
-   echo '';
-}
-
-else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
-{
-  echo'<div class="alert alert-success alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>'.$_GET['msg'].'</div>';
-}
-?>
  <div class="panel-body">
 
 

--- a/ifaces/modification_verification_pesee_sortiesp.php
+++ b/ifaces/modification_verification_pesee_sortiesp.php
@@ -5,28 +5,6 @@
       {  include "tete.php" ?>
    <div class="container">
         <h1>Modifier la pesée n° <?php echo $_POST['id']?> appartenant à la sortie <?php echo $_POST['nsortie']?> </h1> 
-        <?php
-if ($_GET['err'] == "") // SI on a pas de message d'erreur
-{
-   echo'';
-}
-
-else // SINON 
-{
-  echo'<div class="alert alert-danger">'.$_GET['err'].'</div>';
-}
-
-
-if ($_GET['msg'] == "") // SI on a pas de message positif
-{
-   echo '';
-}
-
-else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
-{
-  echo'<div class="alert alert-success alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>'.$_GET['msg'].'</div>';
-}
-?>
  <div class="panel-body">
 
 
@@ -49,7 +27,6 @@ else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
 
 
 
-<?php  ?>
 
 
   <div class="col-md-3">

--- a/ifaces/modification_verification_pesee_sortiesr.php
+++ b/ifaces/modification_verification_pesee_sortiesr.php
@@ -5,28 +5,6 @@
       {  include "tete.php" ?>
    <div class="container">
         <h1>Modifier la pesée n° <?php echo $_POST['id']?> appartenant à la sortie <?php echo $_POST['nsortie']?> </h1> 
-        <?php
-if ($_GET['err'] == "") // SI on a pas de message d'erreur
-{
-   echo'';
-}
-
-else // SINON 
-{
-  echo'<div class="alert alert-danger">'.$_GET['err'].'</div>';
-}
-
-
-  if ($_GET['msg'] == "") // SI on a pas de message positif
-{
-   echo '';
-}
-
-else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
-{
-  echo'<div class="alert alert-success alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>'.$_GET['msg'].'</div>';
-}
-?>
  <div class="panel-body">
 
 

--- a/ifaces/modification_verification_remboursement.php
+++ b/ifaces/modification_verification_remboursement.php
@@ -5,28 +5,6 @@
       {  include "tete.php" ?>
    <div class="container">
         <h1>Modifier le remboursement n° <?php echo $_GET['nvente']?></h1> 
-        <?php
-if ($_GET['err'] == "") // SI on a pas de message d'erreur
-{
-   echo'';
-}
-
-else // SINON 
-{
-  echo'<div class="alert alert-danger">'.$_GET['err'].'</div>';
-}
-
-
-if ($_GET['msg'] == "") // SI on a pas de message positif
-{
-   echo '';
-}
-
-else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
-{
-  echo'<div class="alert alert-success alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>'.$_GET['msg'].'</div>';
-}
-?>
  <div class="panel-body">
 
 

--- a/ifaces/modification_verification_sorties.php
+++ b/ifaces/modification_verification_sorties.php
@@ -5,28 +5,6 @@
       {  include "tete.php" ?>
    <div class="container">
         <h1>Modifier la sortie n° <?php echo $_GET['nsortie']?></h1> 
-        <?php
-if ($_GET['err'] == "") // SI on a pas de message d'erreur
-{
-   echo'';
-}
-
-else // SINON 
-{
-  echo'<div class="alert alert-danger">'.$_GET['err'].'</div>';
-}
-
-
-if ($_GET['msg'] == "") // SI on a pas de message positif
-{
-   echo '';
-}
-
-else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
-{
-  echo'<div class="alert alert-success alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>'.$_GET['msg'].'</div>';
-}
-?>
  <div class="panel-body">
 
 

--- a/ifaces/modification_verification_sortiesc.php
+++ b/ifaces/modification_verification_sortiesc.php
@@ -5,28 +5,6 @@
       {  include "tete.php" ?>
    <div class="container">
         <h1>Modifier la sortie n° <?php echo $_GET['nsortie']?></h1> 
-        <?php
-if ($_GET['err'] == "") // SI on a pas de message d'erreur
-{
-   echo'';
-}
-
-else // SINON 
-{
-  echo'<div class="alert alert-danger">'.$_GET['err'].'</div>';
-}
-
-
-if ($_GET['msg'] == "") // SI on a pas de message positif
-{
-   echo '';
-}
-
-else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
-{
-  echo'<div class="alert alert-success alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>'.$_GET['msg'].'</div>';
-}
-?>
  <div class="panel-body">
 
 

--- a/ifaces/modification_verification_sortiesd.php
+++ b/ifaces/modification_verification_sortiesd.php
@@ -5,28 +5,6 @@
       {  include "tete.php" ?>
    <div class="container">
         <h1>Modifier la sortie n° <?php echo $_GET['nsortie']?></h1> 
-        <?php
-if ($_GET['err'] == "") // SI on a pas de message d'erreur
-{
-   echo'';
-}
-
-else // SINON 
-{
-  echo'<div class="alert alert-danger">'.$_GET['err'].'</div>';
-}
-
-
-if ($_GET['msg'] == "") // SI on a pas de message positif
-{
-   echo '';
-}
-
-else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
-{
-  echo'<div class="alert alert-success alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>'.$_GET['msg'].'</div>';
-}
-?>
  <div class="panel-body">
 
 

--- a/ifaces/modification_verification_sortiesp.php
+++ b/ifaces/modification_verification_sortiesp.php
@@ -5,28 +5,6 @@
       {  include "tete.php" ?>
    <div class="container">
         <h1>Modifier la sortie n° <?php echo $_GET['nsortie']?></h1> 
-        <?php
-if ($_GET['err'] == "") // SI on a pas de message d'erreur
-{
-   echo'';
-}
-
-else // SINON 
-{
-  echo'<div class="alert alert-danger">'.$_GET['err'].'</div>';
-}
-
-
-if ($_GET['msg'] == "") // SI on a pas de message positif
-{
-   echo '';
-}
-
-else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
-{
-  echo'<div class="alert alert-success alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>'.$_GET['msg'].'</div>';
-}
-?>
  <div class="panel-body">
 
 

--- a/ifaces/modification_verification_sortiesr.php
+++ b/ifaces/modification_verification_sortiesr.php
@@ -5,28 +5,6 @@
       {  include "tete.php" ?>
    <div class="container">
         <h1>Modifier la sortie n° <?php echo $_GET['nsortie']?></h1> 
-        <?php
-if ($_GET['err'] == "") // SI on a pas de message d'erreur
-{
-   echo'';
-}
-
-else // SINON 
-{
-  echo'<div class="alert alert-danger">'.$_GET['err'].'</div>';
-}
-
-
-if ($_GET['msg'] == "") // SI on a pas de message positif
-{
-   echo '';
-}
-
-else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
-{
-  echo'<div class="alert alert-success alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>'.$_GET['msg'].'</div>';
-}
-?>
  <div class="panel-body">
 
 

--- a/ifaces/modification_verification_vente.php
+++ b/ifaces/modification_verification_vente.php
@@ -5,28 +5,6 @@
       {  include "tete.php" ?>
    <div class="container">
         <h1>Modifier la vente n° <?php echo $_GET['nvente']?></h1> 
-        <?php
-if ($_GET['err'] == "") // SI on a pas de message d'erreur
-{
-   echo'';
-}
-
-else // SINON 
-{
-  echo'<div class="alert alert-danger">'.$_GET['err'].'</div>';
-}
-
-
-if ($_GET['msg'] == "") // SI on a pas de message positif
-{
-   echo '';
-}
-
-else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
-{
-  echo'<div class="alert alert-success alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>'.$_GET['msg'].'</div>';
-}
-?>
  <div class="panel-body">
 
 

--- a/ifaces/moyens_paiment.php
+++ b/ifaces/moyens_paiment.php
@@ -7,32 +7,6 @@
         <h1>Gestion des moyens de paiement en caisse</h1> 
          <div class="panel-heading">Gérez ici les moyens de paiement disponibles aux différents points de vente</div>
          <p>Permet de définir les différents moyens de paiement disponibles aux différents points de vente.</p>
-<?php
-if ($_GET['err'] == "") // SI on a pas de message d'erreur
-{
-   echo'';
-}
-
-else // SINON 
-{
-  echo'<div class="alert alert-danger">'.$_GET['err'].'</div>';
-}
-
-
-if ($_GET['msg'] == "") // SI on a pas de message positif
-{
-   echo '';
-}
-
-else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
-{
-  echo'<div class="alert alert-success alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>'.$_GET['msg'].'</div>';
-}
-?>
-
-
-
-
 
       <div class="panel-body">
         <div class="row">

--- a/ifaces/remboursement.php
+++ b/ifaces/remboursement.php
@@ -6,28 +6,6 @@ if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($
 
 
 <div class="panel-body">
-  <?php
-if ($_GET['err'] == "") // SI on a pas de message d'erreur
-{
-   echo'';
-}
-
-else // SINON 
-{
-  echo'<div class="alert alert-danger">'.$_GET['err'].'</div>';
-}
-
-
-if ($_GET['msg'] == "") // SI on a pas de message positif
-{
-   echo '';
-}
-
-else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
-{
-  echo'<div class="alert alert-success alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>'.$_GET['msg'].'</div>';
-}
-?>
       <fieldset>
       <legend>
              <?php 

--- a/ifaces/sorties.php
+++ b/ifaces/sorties.php
@@ -165,28 +165,6 @@ function tdechet_clear()
                 ?>  
 }
 </script>
-<?php
-if ($_GET['err'] == "") // SI on a pas de message d'erreur
-{
-   echo'';
-}
-
-else // SINON 
-{
-  echo'<div class="alert alert-danger">'.$_GET['err'].'</div>';
-}
-
-
-if ($_GET['msg'] == "") // SI on a pas de message positif
-{
-   echo '';
-}
-
-else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
-{
-  echo'<div class="alert alert-success alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>'.$_GET['msg'].'</div>';
-}
-?>
 <div class="panel-body">
           <fieldset>
        <legend>

--- a/ifaces/sortiesc.php
+++ b/ifaces/sortiesc.php
@@ -194,28 +194,6 @@ function tdechet_clear()
 
 }
 </script>
-<?php
-if ($_GET['err'] == "") // SI on a pas de message d'erreur
-{
-   echo'';
-}
-
-else // SINON 
-{
-  echo'<div class="alert alert-danger">'.$_GET['err'].'</div>';
-}
-
-
-if ($_GET['msg'] == "") // SI on a pas de message positif
-{
-   echo '';
-}
-
-else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
-{
-  echo'<div class="alert alert-success alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>'.$_GET['msg'].'</div>';
-}
-?>
 <div class="panel-body">
           <fieldset>
        <legend>

--- a/ifaces/sortiesd.php
+++ b/ifaces/sortiesd.php
@@ -151,28 +151,6 @@ function tdechet_clear()
                 ?>  
 }
 </script>
-<?php
-if ($_GET['err'] == "") // SI on a pas de message d'erreur
-{
-   echo'';
-}
-
-else // SINON 
-{
-  echo'<div class="alert alert-danger">'.$_GET['err'].'</div>';
-}
-
-
-if ($_GET['msg'] == "") // SI on a pas de message positif
-{
-   echo '';
-}
-
-else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
-{
-  echo'<div class="alert alert-success alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>'.$_GET['msg'].'</div>';
-}
-?>
 <div class="panel-body">
           <fieldset>
        <legend>

--- a/ifaces/sortiesp.php
+++ b/ifaces/sortiesp.php
@@ -138,28 +138,6 @@ function tdechet_clear()
                 ?>  
 }
 </script>
-<?php
-if ($_GET['err'] == "") // SI on a pas de message d'erreur
-{
-   echo'';
-}
-
-else // SINON 
-{
-  echo'<div class="alert alert-danger">'.$_GET['err'].'</div>';
-}
-
-
-if ($_GET['msg'] == "") // SI on a pas de message positif
-{
-   echo '';
-}
-
-else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
-{
-  echo'<div class="alert alert-success alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>'.$_GET['msg'].'</div>';
-}
-?>
 <div class="panel-body">
           <fieldset>
        <legend>

--- a/ifaces/sortiesr.php
+++ b/ifaces/sortiesr.php
@@ -194,28 +194,6 @@ function submanut(x)
           
    
 </script>
-<?php
-if ($_GET['err'] == "") // SI on a pas de message d'erreur
-{
-   echo'';
-}
-
-else // SINON 
-{
-  echo'<div class="alert alert-danger">'.$_GET['err'].'</div>';
-}
-
-
-if ($_GET['msg'] == "") // SI on a pas de message positif
-{
-   echo '';
-}
-
-else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
-{
-  echo'<div class="alert alert-success alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>'.$_GET['msg'].'</div>';
-}
-?>
 <div class="panel-body">
           <fieldset>
        <legend>

--- a/ifaces/tete.php
+++ b/ifaces/tete.php
@@ -232,3 +232,13 @@ if(strpos($_SESSION['niveau'], 'bi') !== false)
 </div><!--/.navbar-collapse -->
       </div>
     </div>
+
+<?php
+
+// Afficher l'erreur si elle existe
+if (isset($_GET['err'])) echo "<div class='alert alert-danger' style='width:80%;margin:auto;'>$_GET[err]</div>";
+
+// Affiche le message s'il existe
+if (isset($_GET['msg'])) echo "<div class='alert alert-success alert-dismissable' style='width:80%;margin:auto;'><button type='button' class='close' data-dismiss='alert' aria-hidden='true'>&times;</button>$_GET[msg]</div>";
+
+?>

--- a/ifaces/types_collecte.php
+++ b/ifaces/types_collecte.php
@@ -7,32 +7,6 @@
         <h1>Gestion de la typologie des collectes</h1> 
          <div class="panel-heading">Gérez ici les différents types de collectes</div>
          <p>Permet de différencier les collectes en fonction de leur origine (apport volontaire, collecte à domicile, collecte en pied d'immeuble...) </p>
-<?php
-if ($_GET['err'] == "") // SI on a pas de message d'erreur
-{
-   echo'';
-}
-
-else // SINON 
-{
-  echo'<div class="alert alert-danger">'.$_GET['err'].'</div>';
-}
-
-
-if ($_GET['msg'] == "") // SI on a pas de message positif
-{
-   echo '';
-}
-
-else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
-{
-  echo'<div class="alert alert-success alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>'.$_GET['msg'].'</div>';
-}
-?>
-
-
-
-
 
       <div class="panel-body">
         <div class="row">

--- a/ifaces/types_dechets.php
+++ b/ifaces/types_dechets.php
@@ -7,32 +7,6 @@
         <h1>Gestion de la typologie des objets collectés</h1> 
          <div class="panel-heading">Gérez ici la typologie des différents objets collectés par la structure.</div>
          <p>Permet de créer son propre jeu de sept famille (ou plus) des objets collectés</p>
-<?php
-if ($_GET['err'] == "") // SI on a pas de message d'erreur
-{
-   echo'';
-}
-
-else // SINON 
-{
-  echo'<div class="alert alert-danger">'.$_GET['err'].'</div>';
-}
-
-
-if ($_GET['msg'] == "") // SI on a pas de message positif
-{
-   echo '';
-}
-
-else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
-{
-  echo'<div class="alert alert-success alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>'.$_GET['msg'].'</div>';
-}
-?>
-
-
-
-
 
       <div class="panel-body">
         <div class="row">

--- a/ifaces/types_dechets_evac.php
+++ b/ifaces/types_dechets_evac.php
@@ -7,33 +7,6 @@
         <h1>Gestion de la typologie des déchets évacués</h1> 
          <div class="panel-heading">Gérez ici les différents types de déchets évacués par la structure.</div>
          <p>Permet de gérer par classes les déchets et matériaux sortant de la structure</p>
-<?php
-if ($_GET['err'] == "") // SI on a pas de message d'erreur
-{
-   echo'';
-}
-
-else // SINON 
-{
-  echo'<div class="alert alert-danger">'.$_GET['err'].'</div>';
-}
-
-
-if ($_GET['msg'] == "") // SI on a pas de message positif
-{
-   echo '';
-}
-
-else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
-{
-  echo'<div class="alert alert-success alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>'.$_GET['msg'].'</div>';
-}
-?>
-
-
-
-
-
       <div class="panel-body">
         <div class="row">
         	<form action="../moteur/types_dechets_evac_post.php" method="post">

--- a/ifaces/utilisateurs.php
+++ b/ifaces/utilisateurs.php
@@ -11,28 +11,6 @@ if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($
   
 </ul>
     <br>     
-<?php
-if ($_GET['err'] == "") // SI on a pas de message d'erreur
-{
-   echo'';
-}
-
-else // SINON 
-{
-  echo'<div class="alert alert-danger">'.$_GET['err'].'</div>';
-}
-
-
-if ($_GET['msg'] == "") // SI on a pas de message positif
-{
-   echo '';
-}
-
-else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
-{
-  echo'<div class="alert alert-success alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>'.$_GET['msg'].'</div>';
-}
-?>
 <div class="panel-body">
         <div class="row">
             <form action="../moteur/inscription_post.php" method="post">

--- a/ifaces/ventes.php
+++ b/ifaces/ventes.php
@@ -60,24 +60,6 @@ if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND (strpos($
               $req->closeCursor(); // Termine le traitement de la requête
         ?>
       </legend> 
-        <?php
-if ($_GET['err'] == "") // SI on a pas de message d'erreur
-{
-   echo'';
-}
-else // SINON 
-{
-  echo'<div class="alert alert-danger">'.$_GET['err'].'</div>';
-}
-if ($_GET['msg'] == "") // SI on a pas de message positif
-{
-   echo '';
-}
-else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
-{
-  echo'<div class="alert alert-success alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-text="true">&times;</button>'.$_GET['msg'].'</div>';
-}
-?>  
       </fieldset>     
     <div class="row">
 

--- a/ifaces/verif_collecte.php
+++ b/ifaces/verif_collecte.php
@@ -19,28 +19,6 @@
       {  include "tete.php" ?>
    <div class="container" style="width:1300px">
         <h1>Vérification des collectes</h1> 
-        <?php
-if ($_GET['err'] == "") // SI on a pas de message d'erreur
-{
-   echo'';
-}
-
-else // SINON 
-{
-  echo'<div class="alert alert-danger">'.$_GET['err'].'</div>';
-}
-
-
-if ($_GET['msg'] == "") // SI on a pas de message positif
-{
-   echo '';
-}
-
-else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
-{
-  echo'<div class="alert alert-success alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>'.$_GET['msg'].'</div>';
-}
-?>
  <div class="panel-body">
 <ul class="nav nav-tabs">
 

--- a/ifaces/verif_sorties.php
+++ b/ifaces/verif_sorties.php
@@ -24,28 +24,6 @@
 
    <div class="container">
         <h1>Vérification des sorties hors-boutique</h1> 
-        <?php
-if ($_GET['err'] == "") // SI on a pas de message d'erreur
-{
-   echo'';
-}
-
-else // SINON 
-{
-  echo'<div class="alert alert-danger">'.$_GET['err'].'</div>';
-}
-
-
-if ($_GET['msg'] == "") // SI on a pas de message positif
-{
-   echo '';
-}
-
-else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
-{
-  echo'<div class="alert alert-success alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>'.$_GET['msg'].'</div>';
-}
-?>
  <div class="panel-body">
 <ul class="nav nav-tabs">
 

--- a/ifaces/verif_vente.php
+++ b/ifaces/verif_vente.php
@@ -19,28 +19,6 @@
       {  include "tete.php" ?>
    <div class="container">
         <h1>verification des ventes</h1> 
-        <?php
-if ($_GET['err'] == "") // SI on a pas de message d'erreur
-{
-   echo'';
-}
-
-else // SINON 
-{
-  echo'<div class="alert alert-danger">'.$_GET['err'].'</div>';
-}
-
-
-if ($_GET['msg'] == "") // SI on a pas de message positif
-{
-   echo '';
-}
-
-else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
-{
-  echo'<div class="alert alert-success alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>'.$_GET['msg'].'</div>';
-}
-?>
  <div class="panel-body">
 <ul class="nav nav-tabs">
 

--- a/ifaces/viz_caisse.php
+++ b/ifaces/viz_caisse.php
@@ -22,28 +22,6 @@
         <p align="right">
         <input class="btn btn-default btn-lg" type='button'name='quitter' value='Quitter' OnClick="window.close();"/></p>
 
-        <?php
-if ($_GET['err'] == "") // SI on a pas de message d'erreur
-{
-   echo'';
-}
-
-else // SINON 
-{
-  echo'<div class="alert alert-danger">'.$_GET['err'].'</div>';
-}
-
-
-if ($_GET['msg'] == "") // SI on a pas de message positif
-{
-   echo '';
-}
-
-else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
-{
-  echo'<div class="alert alert-success alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>'.$_GET['msg'].'</div>';
-}
-?>
  <div class="panel-body">
 
 

--- a/ifaces/viz_remboursement.php
+++ b/ifaces/viz_remboursement.php
@@ -7,28 +7,6 @@
         <h1>Visualiser le remboursement n° <?php echo $_GET['nvente']?></h1> 
         <p align="right">
         <input class="btn btn-default btn-lg" type='button'name='quitter' value='Quitter' OnClick="window.close();"/></p>
-        <?php
-if ($_GET['err'] == "") // SI on a pas de message d'erreur
-{
-   echo'';
-}
-
-else // SINON 
-{
-  echo'<div class="alert alert-danger">'.$_GET['err'].'</div>';
-}
-
-
-if ($_GET['msg'] == "") // SI on a pas de message positif
-{
-   echo '';
-}
-
-else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
-{
-  echo'<div class="alert alert-success alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>'.$_GET['msg'].'</div>';
-}
-?>
  <div class="panel-body">
 
 

--- a/ifaces/viz_vente.php
+++ b/ifaces/viz_vente.php
@@ -1,34 +1,15 @@
 <?php session_start();
 
+
+
 //Vérification des autorisations de l'utilisateur et des variables de session requises pour l'affichage de cette page:
    if (isset($_SESSION['id']) AND $_SESSION['systeme'] = "oressource" AND $_SESSION['viz_caisse'] = "oui" AND (strpos($_SESSION['niveau'], 'v'.$_GET['numero']) !== false)  )
-      {  include "tete.php" ?>
+      {  include "tete.php"
+?>
    <div class="container">
         <h1>Visualiser la vente n° <?php echo $_GET['nvente']?></h1> 
         <p align="right">
         <input class="btn btn-default btn-lg" type='button'name='quitter' value='Quitter' OnClick="window.close();"/></p>
-        <?php
-if ($_GET['err'] == "") // SI on a pas de message d'erreur
-{
-   echo'';
-}
-
-else // SINON 
-{
-  echo'<div class="alert alert-danger">'.$_GET['err'].'</div>';
-}
-
-
-if ($_GET['msg'] == "") // SI on a pas de message positif
-{
-   echo '';
-}
-
-else // SINON (la variable ne contient ni Oui ni Non, on ne peut pas agir)
-{
-  echo'<div class="alert alert-success alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>'.$_GET['msg'].'</div>';
-}
-?>
  <div class="panel-body">
 
 


### PR DESCRIPTION

L'affichage des erreurs et des messages peut se faire à la fin du fichier tete.php 

De cette manière on évite de répéter le même code en haut de chaque page.