### PR TITLE
Ecran de vente : simplification des boutons

### DIFF
--- a/ifaces/ventes.php
+++ b/ifaces/ventes.php
@@ -205,46 +205,88 @@ Somme due:
   </div>
   <div class="panel-body"> 
       
+<?php 
 
+//
+// Affichage des différents Types de déchets ( "Types d'objet" )
+// avec les tarifs pré-définis (s'il y en a)
+//
 
-            <?php 
-            // On recupère tout le contenu de la table point de collecte
-            $reponse = $bdd->query('SELECT * FROM type_dechets WHERE visible = "oui"');
+// On recupère tout les types des déchets "actifs"
+$dechets = $bdd->query('SELECT * FROM type_dechets WHERE visible = "oui"');
  
-           // On affiche chaque entree une à une
-           while ($donnees = $reponse->fetch())
-           {
-           ?>
-      <div class="btn-group">
-      <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" style="margin-left:8px; margin-top:16px;">
-      <span class="badge" id="cool" style="background-color:<?php echo$donnees['couleur']?>"><?php echo$donnees['nom']?></span>
-      </button>
-      <ul class="dropdown-menu" role="menu">
-      <li style="font-size:18px"><a href="javascript:edite('<?php echo$donnees['nom']?>','0','<?php echo$donnees['id']?>','0')" ><?php echo$donnees['nom']?></a></li>
-      <li class="divider"></li>
+// On affiche un bouton pour chaque type de déchet 
+while ($d = $dechets->fetch())
+{
+      	$couleur_dechet=$d['couleur'];
+       	$id_dechet=$d['id'];
+       	$nom_dechet=$d['nom'];
+	$action_dechet="javascript:edite('$nom_dechet','0','$id_dechet','0')";
 
+	print "<div class='btn-group'>";
+		
+	// On récupère la grille de tarifs pour ce type de déchets
+        $tarifs = $bdd->prepare('SELECT * FROM grille_objets WHERE id_type_dechet = :id_type_dechet AND visible = "oui"  ORDER BY nom ');
+        $tarifs->execute(array('id_type_dechet' => $id_dechet));
 
-  <?php 
-             // On recupère tout le contenu de la table grille_objets
-           $req = $bdd->prepare('SELECT * FROM grille_objets WHERE id_type_dechet = :id_type_dechet AND visible = "oui"  ORDER BY nom ');
-           $req->execute(array('id_type_dechet' => $donnees['id']));
-           $i = 1;
-           // On affiche chaque entree une à une
-           while ($donneesint = $req->fetch())
-           {
-           ?>
-    <li style="font-size:18px"><a href="javascript:edite('<?php echo$donneesint['nom']?>','<?php echo$donneesint['prix']?>','<?php echo$donnees['id']?>','<?php echo$donneesint['id']?>')"><?php echo$donneesint['nom']?></a></li>
-    </li>
-           <?php }
-           $req->closeCursor(); // Termine le traitement de la requête
-           ?> 
-    </ul>
-    </div>
-   
-                <?php }
-                $reponse->closeCursor(); // Termine le traitement de la requête
-                ?>
-    </div> 
+	// S'il n'y pas de tarif pour ce type de déchets
+	// Alors on affiche un bouton tout simple 	
+	if ($tarifs->rowCount() == 0 )
+	{
+		print "<button type='button' class='btn btn-default' style='margin-left:8px; margin-top:16px;'>";
+		print "<span class='badge' id='cool' style='background-color:$couleur_dechet'>";
+		print "<a href=\"$action_dechet\" style='color:#ffffff;'>$nom_dechet</a>";
+		print "</span>";
+      		print "</button>";
+	} else {
+
+	// S'il y a une grille de tarif pour ce type 
+	// Alors on affiche un menu déroulant		 
+
+		// Le premier item du menu déroulant c'est le type de déchet lui-même (avec un prix pré-défini à 0)
+		print "<button type='button' class='btn btn-default dropdown-toggle' data-toggle='dropdown' style='margin-left:8px; margin-top:16px;'>";
+      		print "<span class='badge' id='cool' style='background-color:$couleur_dechet'>$nom_dechet</span>";
+      		print "</button>";
+      		print "<ul class='dropdown-menu' role='menu'>";
+      		print "<li style='font-size:18px'>";
+		print "<a href=\"$action_dechet\" >$nom_dechet</a>";
+		print "</li>";
+			
+		// un séparateur
+      		print "<li class='divider'></li>"; 
+     
+		// Ensuite on récupère chaque ligne de la grille de tarif
+		// et on ajoute un item dans le menu déroulant
+                while ($t = $tarifs->fetch())
+           	{
+			$id_tarif=$t['id'];
+			$prix_tarif=$t['prix'];
+			$nom_tarif=$t['nom'];
+			$action_tarif="javascript:edite('$nom_tarif','$prix_tarif','$id_dechet',$id_tarif)";
+
+			print "<li style='font-size:18px'>";
+			print "<a href=\"$action_tarif\">$nom_tarif</a>";
+			print "</li>";
+       		}
+
+		// Fin du menu déroulant
+		print "</ul>";
+   	}
+           	
+	// destruction de la grille de tarif
+	$tarifs->closeCursor(); 
+    
+	// Fin du groupe de boutons
+	print "</div>";
+
+}   
+
+// destruction de la liste des déchets
+$dechets->closeCursor(); 
+
+// Fin du Paneau Type d'objet        
+?>
+</div> 
 
 
 


### PR DESCRIPTION

Dans le panneau "Type d'objet" :  

S'il n'y pas de tarif prédéfini pour un type de déchets 
Alors on affiche un bouton tout simple  sans menu déroulant (ce qui fait  click de moins pour l'utilisateur)

Sinon s'il y a une grille de tarif  pour ce type de déchets
Alors on affiche un menu déroulant comme avant


