### PR TITLE
Ne pas envoyer les mots de passe sur le dépot Git :)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-
+moteur/dbconfig.php

--- a/mysql/recap_CA_par_mode_paiement.sql
+++ b/mysql/recap_CA_par_mode_paiement.sql
@@ -1,7 +1,7 @@
 SELECT 
 	ventes.id_moyen_paiement AS id_moyen, 
 	moyens_paiement.nom AS moyen,
-	COUNT(vendus.id) AS quantite_vendue, 
+	COUNT(DISTINCT(ventes.id)) AS quantite_vendue, 
 	SUM(vendus.prix*vendus.quantite) AS total, 
 	SUM(vendus.remboursement) AS remboursement 
 FROM 


### PR DESCRIPTION
en ajoutant ce fichier .gitignore est sur que le fichier moteur/dbconfig.php ne sera jamais envoyé sur le dépot github et donc on évite de publier les codes d'accès à la base par erreur.

Pour les utilisateurs qui installe oressource, il faudrait fournir un fichier `dbconfig.php.exemple` qu'ils pourront copier et modifier