### PR TITLE
Fix #139 reset du commentaire dans sorties/collectes.

### DIFF
--- a/js/ticket.js
+++ b/js/ticket.js
@@ -167,7 +167,7 @@ function tickets_clear() {
   range.selectNodeContents(document.getElementById('transaction'));
   range.deleteContents();
 
-  document.getElementById('commentaire').textContent = '';
+  document.getElementById('commentaire').value = '';
   document.getElementById('massetot').textContent = 'Masse totale: 0 Kg.';
 
   // On reset TOUT les tickets. En general il y en aura qu'un...


### PR DESCRIPTION
Fix: https://github.com/mart1ver/oressource/issues/139
Explication:
Source: https://developer.mozilla.org/en/docs/Web/HTML/Element/input

Le commentaire est un DOM élément de type `<input>` il faut donc changer
sa propriété `value` et non `textContent` comme on ferait avec un `<label>`.

