### PR TITLE
Correctifs sur l'API qui empechaient la saisie d'une sortie/collecte/vente.

### DIFF
--- a/api/collectes.php
+++ b/api/collectes.php
@@ -32,7 +32,7 @@ session_start();
 
 header("content-type:application/json");
 
-if (is_valid_session() && is_allowed_saisie_collecte()) {
+if (is_valid_session()) {
 
   $json_raw = file_get_contents('php://input');
   $unsafe_json = json_decode($json_raw, true);
@@ -52,7 +52,7 @@ if (is_valid_session() && is_allowed_saisie_collecte()) {
 
   if (is_allowed_collecte_id($json['id_point'])) {
     try {
-      $timestamp = (is_allowed_edit_date() ? parseDate($json['antidate']) : new DateTime('now'));
+      $timestamp = allowDate($json) ? parseDate($json['date']) : new DateTime('now');
       $collecte = [
         'timestamp' => $timestamp,
         'id_type_action' => $json['id_type_action'],
@@ -73,6 +73,9 @@ if (is_valid_session() && is_allowed_saisie_collecte()) {
       echo(json_encode(['id_collecte' => $id_collecte], JSON_NUMERIC_CHECK));
     } catch (InvalidArgumentException $e) {
       $bdd->rollback();
+      http_response_code(400); // Bad Request
+      echo(json_encode(['error' => $e->getMessage()]));
+    } catch (UnexpectedValueException $e) {
       http_response_code(400); // Bad Request
       echo(json_encode(['error' => $e->getMessage()]));
     }

--- a/api/sorties.php
+++ b/api/sorties.php
@@ -48,8 +48,7 @@ require_once('../core/requetes.php');
 session_start();
 header("content-type:application/json");
 
-if (is_valid_session() && is_allowed_sortie()) {
-
+if (is_valid_session()) {
   try {
     $json_raw = file_get_contents('php://input');
     $unsafe_json = json_decode($json_raw, true);
@@ -67,8 +66,7 @@ if (is_valid_session() && is_allowed_sortie()) {
       echo(json_encode(['error' => 'Action interdite.'], JSON_FORCE_OBJECT));
       die();
     }
-
-    $timestamp = (is_allowed_edit_date() ? parseDate($json['antidate']) : new DateTime('now'));
+    $timestamp = allowDate($json) ? parseDate($json['date']) : new DateTime('now');
     $sortie = [
       'timestamp' => $timestamp,
       'type_sortie' => $json['id_type_action'],

--- a/api/structures.php
+++ b/api/structures.php
@@ -29,7 +29,13 @@ session_start();
 
 header("content-type:application/json");
 
-if (is_valid_session() && is_allowed_config()) {
+if (is_valid_session()) {
+  if (!is_allowed_config()) {
+    http_response_code(403); // Forbiden.
+    echo(json_encode(['error' => 'Action interdite.'], JSON_FORCE_OBJECT));
+    die();
+  }
+
   $json_raw = file_get_contents('php://input');
   $unsafe_json = json_decode($json_raw, true);
 
@@ -39,7 +45,8 @@ if (is_valid_session() && is_allowed_config()) {
   structure_update($bdd, array_merge($structure, [
     'id' => 1,
   ]));
-  http_response_code(200); // Unauthorized.
+
+  http_response_code(200); // Sucess.
   echo(json_encode(['success' => 'Configuration saved']));
 } else {
   http_response_code(401); // Unauthorized.

--- a/core/session.php
+++ b/core/session.php
@@ -169,6 +169,12 @@ function is_vente_visible(array $point_vente): bool {
   return is_allowed_vente_id($point_vente['id']) && $point_vente['visible'] === 'oui';
 }
 
+function allowDate(array $json): bool {
+  return (is_allowed_edit_date()
+          && is_allowed_saisie_collecte()
+          && isset($json['date']));
+}
+
 function droits(array $points, string $type, array $droits): string {
   $d = '';
   $niveau = 'niveau' . $type;


### PR DESCRIPTION
Le bug se produisait si le champ saisiec etait à `non`.
Corrigé en modifiant le code pour vérifer les droits à l'aide du JSON.