### PR TITLE
MySQL >= 5.6.5, MariaDb >= 10.0.1 pour plusieurs timestamp et interdiction des 0 dans les dates

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -3,7 +3,7 @@
 Instalation sous linux (debian/ubuntu)
 
 ## Dépendances
-Il faut une version de MySQL >= à 5.6.5.
+Il faut une version de MySQL >= 5.6.5 et MariaDB >= 10.0.1.
 
 ```shell
 sudo apt-get install mysql-server apache2 php5-mysql libapache2-mod-php5 git

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -3,6 +3,8 @@
 Instalation sous linux (debian/ubuntu)
 
 ## Dépendances
+Il faut une version de MySQL >= à 5.6.5.
+
 ```shell
 sudo apt-get install mysql-server apache2 php5-mysql libapache2-mod-php5 git
 ```

--- a/mysql/upgrade_20161011.sql
+++ b/mysql/upgrade_20161011.sql
@@ -6,6 +6,8 @@
 -- base de données.
 --
 
+SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='';
+
 BEGIN;
 
 ALTER TABLE `description_structure`
@@ -30,3 +32,5 @@ CREATE TABLE IF NOT EXISTS `pesees_vendus` (
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1 AUTO_INCREMENT=1 ;
 
 COMMIT;
+
+SET SQL_MODE=@OLD_SQL_MODE;

--- a/mysql/upgrade_20170627.sql
+++ b/mysql/upgrade_20170627.sql
@@ -6,6 +6,8 @@
 -- base de données.
 --
 
+SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='';
+
 BEGIN;
 
 ALTER TABLE `collectes`
@@ -124,3 +126,5 @@ MODIFY `id_last_hero` int(11) NOT NULL DEFAULT 0,
 MODIFY `last_hero_timestamp` timestamp NOT NULL DEFAULT '0000-00-00 00:00:00' ON UPDATE CURRENT_TIMESTAMP;
 
 COMMIT;
+
+SET SQL_MODE=@OLD_SQL_MODE;


### PR DESCRIPTION
https://dev.mysql.com/doc/relnotes/mysql/5.6/en/news-5-6-5.html#mysqld-5-6-5-data-types
https://jira.mariadb.org/browse/MDEV-452

Sinon on a une erreur :
```ERROR 1293 (HY000) at line 11:
Incorrect table definition; there can be only one TIMESTAMP column 
with CURRENT_TIMESTAMP in DEFAULT or ON UPDATE clause
``` 
Quand on applique le fichier `mysql/upgrade_20170627.sql` par exemple.

Et le mode par défaut de SQL c'est strict plus pas de zéro dans les dates, alors ça coince.