### PR TITLE
🚧 Changements dans le schema SQL champs passé de text à int/DECIMAL.

### DIFF
--- a/mysql/2017-12-24_conformite_strict_SQL.sql
+++ b/mysql/2017-12-24_conformite_strict_SQL.sql
@@ -261,7 +261,13 @@ ALTER TABLE pesees_sorties  MODIFY COLUMN id_type_dechet      int DEFAULT 0;
 ALTER TABLE pesees_sorties  MODIFY COLUMN id_type_poubelle    int DEFAULT 0;
 ALTER TABLE pesees_sorties  MODIFY COLUMN id_type_dechet_evac int DEFAULT 0;
 ALTER TABLE grille_objets   MODIFY COLUMN prix                DECIMAL DEFAULT 0.0 NOT NULL;
+ALTER TABLE types_poubelles MODIFY COLUMN masse_bac           DECIMAL DEFAULT 0.0 NOT NULL;
 ALTER TABLE type_contenants MODIFY COLUMN masse               DECIMAL DEFAULT 0.0 NOT NULL;
+ALTER TABLE points_sortie   MODIFY COLUMN pesee_max           DECIMAL DEFAULT 0.0 NOT NULL;
+ALTER TABLE points_collecte MODIFY COLUMN pesee_max           DECIMAL DEFAULT 0.0 NOT NULL;
+ALTER TABLE points_vente    MODIFY COLUMN surface_vente       DECIMAL DEFAULT 0.0 NOT NULL;
+ALTER TABLE description_structure MODIFY COLUMN taux_tva      DECIMAL DEFAULT 0.0 NOT NULL;
+ALTER TABLE description_structure MODIFY COLUMN id_localite   int DEFAULT 1 NOT NULL;
 
 ALTER TABLE collectes           MODIFY COLUMN last_hero_timestamp timestamp NOT NULL default now() ON UPDATE now();
 ALTER TABLE conventions_sorties MODIFY COLUMN last_hero_timestamp timestamp NOT NULL default now() ON UPDATE now();


### PR DESCRIPTION
On avait des champs `text` qui pouvaient être des `INT` et d'autres des `DECIMALS`.