### PR TITLE
Suppression d'une fonction dupliquée.

### DIFF
--- a/core/requetes.php
+++ b/core/requetes.php
@@ -174,7 +174,9 @@ function convention_sortie(PDO $bdd): array {
 }
 
 function convention_sortie_by_id(PDO $bdd, int $id): array {
-  $sql = 'SELECT id, nom, couleur, description, timestamp, visible FROM conventions_sortie AND id = :id';
+  $sql = 'SELECT id, nom, couleur, visible, description, timestamp, visible
+  FROM conventions_sorties
+  WHERE id = :id';
   return fetch_id($bdd, $sql, $id);
 }
 

--- a/ifaces/modification_conventions_sorties.php
+++ b/ifaces/modification_conventions_sorties.php
@@ -24,18 +24,13 @@ require_once '../core/composants.php';
 require_once '../core/session.php';
 require_once '../core/requetes.php';
 
-function conventions_sorties_id(PDO $bdd, $id): array {
-  $sql = 'SELECT id, nom, couleur, visible, description, timestamp FROM conventions_sorties WHERE id = :id';
-  return fetch_id($bdd, $sql, $id);
-}
-
 if (is_valid_session() && (strpos($_SESSION['niveau'], 'k') !== false)) {
   require_once '../moteur/dbconfig.php';
   require_once 'tete.php';
   $props = array_merge(['h1' => 'Gestion des partenaires de réemploi.',
     'type' => 'partenaire',
     'endpoint' => 'conventions_sorties'
-  ], conventions_sorties_id($bdd, $_POST['id']));
+  ], convention_sortie_by_id($bdd, $_POST['id']));
   ?>
   <?= config_types3_page_modif($props) ?>
   <?php


### PR DESCRIPTION
La fonction était dupliquée et portait un nom différent dans
`modification_conventions_sorties.php`, la fonction sera à présent dans
`requetes.php` à coté des autres fonctions de traitement des convention.