### PR TITLE
Fix d'un bug sur les remboursements

### DIFF
--- a/core/requetes.php
+++ b/core/requetes.php
@@ -534,7 +534,7 @@ function nb_remboursements(PDO $bdd, string $start, string $stop,
   INNER JOIN vendus
   ON ventes.id = vendus.id_vente
   AND vendus.remboursement > 0
-  AND vendus.remboursement = 0
+  AND vendus.prix = 0
     $cond
   AND DATE(vendus.timestamp)
   BETWEEN :du AND :au";

--- a/ifaces/bilanv.php
+++ b/ifaces/bilanv.php
@@ -98,7 +98,7 @@ if (is_valid_session() && is_allowed_bilan()) {
 
       <div class="row">
         <h2><?= ($date1 === $date2) ? "Le $date1" : "Du $date1 au $date2"; ?> :</h2>
-        <?php if (!($bilans['chiffre_degage'] > 0)) { ?>
+        <?php if (!($nb_ventes > 0 || $remb_nb > 0)) { ?>
           <img src="../images/nodata.jpg" class="img-responsive" alt="Responsive image">
           <?php
         } else { ?>

--- a/moteur/remboursement_post.php
+++ b/moteur/remboursement_post.php
@@ -69,6 +69,10 @@ if (is_valid_session() && is_allowed_vente_id($_POST['id_point_vente'])) {
       $tid_objet = 'tid_objet' . $i;
       $tquantite = 'tquantite' . $i;
       $tprix = 'tprix' . $i;
+      if (!($_POST[$tprix] < 0.0)) {
+        header('Location:../ifaces/ventes.php?err=Les remboursement de 0 euros ne sont pas valides &numero=' . $_POST['id_point_vente']);
+        die();
+      }
       $req->bindValue(':id_type_dechet', $_POST[$tid_type_objet], PDO::PARAM_INT);
       $req->bindValue(':id_objet', $_POST[$tid_objet], PDO::PARAM_INT);
       $req->bindValue(':quantite', $_POST[$tquantite], PDO::PARAM_INT);


### PR DESCRIPTION
Les remboursements à 0 euros étaient comptés comme des ventes,
maintenant ce n'est plus possible d'avoir des remboursements à 0.

Un autre bug affectais le calcul du nombre de remboursement.