### PR TITLE
Avertir d'une erreur de connection à la base de donnée

### DIFF
--- a/moteur/dbconfig.php.example
+++ b/moteur/dbconfig.php.example
@@ -35,6 +35,19 @@ try {
     PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION
   ]);
 } catch (PDOException $e) {
-  die('Connexion échouée : ' . $e->getMessage());
+  // Via l'erreur 500 cela se vois dans les log du serveur HTTP.
+  http_response_code(500); // Internal server error
+  echo("<!DOCTYPE html>
+  <html>
+  <head>
+  <meta encoding='utf8'/>
+  </head>
+  <body>
+  <h1>500 Erreur interne de Oressource</h1>
+  <p>Échec de la connection à la base de donnée, contactez votre administrateur il y à un soucis.<p>
+  <p>Une fois le problème résolu vous pouvez recharger la page avec F5 ou la séquence Ctrl-alt-R.</p>
+  </body>
+  </html>");
+  die('Error : Impossible de dialoguer avec la database. ' . $e->getMessage());
 }
 global $bdd;


### PR DESCRIPTION
Cette pull-request ajoute la possibilité de voir quand on à une erreur de base de donnée.

Elle intègre dans le `dbconfig.php` un peu de code pour afficher une page d'erreur qui invite à contacter un administrateur et ou a recharger la page.

Pour développer ça évite de comme moi chercher pendant 10minutes un problème qui ne laisse pas de log, c'est à dire avoir son serveur de base de donnée non démarrée...
![error_db](https://user-images.githubusercontent.com/2827553/49344492-2611a880-f678-11e8-9a1c-7e7b42c192fe.png)

