### PR TITLE
Fix de bugs de typages sur les login et insertion utilisateur

### DIFF
--- a/core/requetes.php
+++ b/core/requetes.php
@@ -141,7 +141,7 @@ function utilisateur_insert(PDO $bdd, array $utilisateur): int {
   $stmt->bindParam(':id_createur', $_SESSION['id'], PDO::PARAM_INT);
   $stmt->bindParam(':id_createur1', $_SESSION['id'], PDO::PARAM_INT);
   $stmt->execute();
-  $id = $bdd->lastInsertId();
+  $id = (int) $bdd->lastInsertId();
   $stmt->closeCursor();
   return $id;
 }
@@ -448,7 +448,7 @@ function login_user(PDO $bdd, string $email, string $password): array {
   $req->execute();
   $user = $req->fetch(PDO::FETCH_ASSOC);
   $req->closeCursor();
-  if ($user !== NULL) {
+  if ($user) {
     return $user;
   }
   throw new Exception('Mot de passe ou nom de compte invalide.');


### PR DESCRIPTION
L'erreur principale était celle ci:

```
[Thu Apr 18 10:48:18 2019] PHP Fatal error:  Uncaught TypeError:
Return value of login_user() must be of the type array,
boolean returned in /Oressource/oressource/core/requetes.php:452
Stack trace:
login_user(Object(PDO), 'admin@oressourc...', '1234')
  thrown in /Oressource/oressource/core/requetes.php on line 452
[Thu Apr 18 10:48:18 2019] 127.0.0.1:48330 [200]: /moteur/login_post.php
 - Uncaught TypeError: Return value of login_user() must be of the type
 array, boolean returned in /Oressource/oressource/core/requetes.php:452
Stack trace:
 login_user(Object(PDO), 'admin@oressourc...', '1234')
  thrown in /Oressource/oressource/core/requetes.php on line 452
```
