### PR TITLE
Fix #320 redirections infinies.

### DIFF
--- a/core/composants.php
+++ b/core/composants.php
@@ -20,23 +20,44 @@
 require_once '../core/validation.php';
 
 /* Fonction utile pour la nav des sorties. */
-function new_nav(string $text, int $numero, int $active): array {
+
+
+function new_nav_sorties(): array {
   $links = [
-    [affichage_sortie_poubelle(), ['href' => "sortiesp.php?numero=$numero", 'text' => 'Poubelles']],
-    [affichage_sortie_partenaires(), ['href' => "sortiesc.php?numero=$numero", 'text' => 'Sorties partenaires']],
-    [affichage_sortie_recyclage(), ['href' => "sortiesr.php?numero=$numero", 'text' => 'Recyclage']],
-    [affichage_sortie_don(), ['href' => "sorties.php?numero=$numero", 'text' => 'Dons']],
-    [affichage_sortie_dechetterie(), ['href' => "sortiesd.php?numero=$numero", 'text' => 'Déchetterie']],
+    ['visible' => affichage_sortie_poubelle(), 'href' => "sortiesp.php", 'text' => 'Poubelles'],
+    ['visible' => affichage_sortie_partenaires(), 'href' => "sortiesc.php", 'text' => 'Sorties partenaires'],
+    ['visible' => affichage_sortie_recyclage(), 'href' => "sortiesr.php", 'text' => 'Recyclage'],
+    ['visible' => affichage_sortie_don(), 'href' => "sorties.php", 'text' => 'Dons'],
+    ['visible' => affichage_sortie_dechetterie(), 'href' => "sortiesd.php", 'text' => 'Déchetterie'],
   ];
-  $l = array_map(function ($e) {
-    if ($e[0] === true) {
-      return $e[1];
-    }
+
+  // Don't keep not visibles sorties first remove invisible,
+  // Then throw away the boolean.
+  return $links;
+}
+
+// ⚠ FIXME ⚠ this function is really fragile due to the way we manage
+// sortie this needs a complete rewrite.
+// Rewrited to fix: https://github.com/mart1ver/oressource/issues/370
+function new_nav(string $text, int $numero, int $active): array {
+  $links = new_nav_sorties();
+  // add numero in url fragment
+  $links = array_map(function (array $e) use ($numero) {
+    $e['href'] .= "?numero={$numero}";
+    return $e;
   }, $links);
-  $l[$active]['state'] = true;
+
+  // WARNING: A hack to get the active.
+  $links[$active]['state'] = true;
+
+  // Filter visibles
+  $links = array_values(array_filter($links, function (array $e) {
+    return $e['visible'];
+  }));
+
   $nav = [
     'text' => $text,
-    'links' => $l
+    'links' => $links
   ];
   return $nav;
 }

--- a/ifaces/sorties.php
+++ b/ifaces/sorties.php
@@ -32,7 +32,7 @@ $numero = filter_input(INPUT_GET, 'numero', FILTER_VALIDATE_INT);
 
 if (is_valid_session() && is_allowed_sortie_id($numero)) {
   if (!affichage_sortie_don()) {
-    header("Location:sortiesd.php?numero=" . $numero);
+    header("Location:index.php");
     die();
   }
 

--- a/ifaces/sortiesc.php
+++ b/ifaces/sortiesc.php
@@ -30,7 +30,7 @@ $numero = filter_input(INPUT_GET, 'numero', FILTER_VALIDATE_INT);
 
 if (is_valid_session() && is_allowed_sortie_id($numero)) {
   if (!affichage_sortie_partenaires()) {
-    header("Location:sortiesr.php?numero=" . $numero);
+    header("Location:index.php");
     die();
   }
 

--- a/ifaces/sortiesd.php
+++ b/ifaces/sortiesd.php
@@ -27,7 +27,7 @@ $numero = filter_input(INPUT_GET, 'numero', FILTER_VALIDATE_INT);
 
 if (is_valid_session() && is_allowed_sortie_id($numero)) {
   if (!affichage_sortie_dechetterie()) {
-    header("Location:sortiesp.php?numero=" . $numero);
+    header("Location:index.php");
     die();
   }
 

--- a/ifaces/sortiesp.php
+++ b/ifaces/sortiesp.php
@@ -27,7 +27,7 @@ $numero = filter_input(INPUT_GET, 'numero', FILTER_VALIDATE_INT);
 
 if (is_valid_session() && is_allowed_sortie_id($numero)) {
   if (!affichage_sortie_poubelle()) {
-    header("Location:sortiesc.php?numero=" . $numero);
+    header("Location:index.php");
     die();
   }
 

--- a/ifaces/sortiesr.php
+++ b/ifaces/sortiesr.php
@@ -27,7 +27,7 @@ $numero = filter_input(INPUT_GET, 'numero', FILTER_VALIDATE_INT);
 
 if (is_valid_session() && is_allowed_sortie_id($numero)) {
   if (!affichage_sortie_recyclage()) {
-    header("Location:sorties.php?numero=" . $numero);
+    header("Location:index.php");
     die();
   }
 

--- a/ifaces/tete.php
+++ b/ifaces/tete.php
@@ -20,6 +20,7 @@
 require_once('../core/requetes.php');
 require_once('../core/session.php');
 require_once('../moteur/dbconfig.php');
+require_once('../core/composants.php');
 
 global $bdd;
 
@@ -29,6 +30,9 @@ $can_verif = is_allowed_verifications();
 $can_users = is_allowed_users();
 $can_parners = is_allowed_partners();
 $can_config = is_allowed_config();
+
+// FIXME: mostly a fix of
+$nav = filter_visibles(new_nav_sorties());
 ?>
 <!DOCTYPE html>
 <html lang="fr">
@@ -80,15 +84,15 @@ $can_config = is_allowed_config();
             }
             ?>
 
-            <?php if (is_allowed_sortie()) { ?>
+            <?php if (is_allowed_sortie() && count($nav) > 0) { ?>
               <li class="nav navbar-nav dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">Sorties hors-boutique<b class="caret"></b></a>
                   <ul class="dropdown-menu">
                     <?php foreach (filter_visibles(points_sorties($bdd)) as $point_sortie) {
-                      if (is_allowed_sortie_id($point_sortie['id'])) {
-                        ?>
+                      // ⚠ Hack to fix https://github.com/mart1ver/oressource/issues/370
+                      if (is_allowed_sortie_id($point_sortie['id'])) { ?>
                         <li>
-                          <a href="../ifaces/sortiesc.php?numero=<?= "{$point_sortie['id']}"; ?>"><?= $point_sortie['nom']; ?></a>
+                          <a href="<?= "{$nav[0]['href']}?numero={$point_sortie['id']}" ?>"><?= $point_sortie['nom']; ?></a>
                         </li>
                         <?php
                       }


### PR DESCRIPTION
Avant dans certaines configurations il était possible d'avoir
une boucle de redirection infinie, maintenant si une page est
inaccessible on redirige vers `index.php`.

C'est pas du code glorieux une reecriture du code de gestion des gui
des sorties vraiment important.

https://github.com/mart1ver/oressource/issues/370