### PR TITLE
Fix typo dans le code de `configs.php`.

### DIFF
--- a/core/configs.php
+++ b/core/configs.php
@@ -146,7 +146,7 @@ function point_ventePost(PDO $bdd) {
 
 function point_sortiePost(PDO $bdd) {
   $data = array_merge(generic_ctor_post(), point_Post(), [
-    'pesee_max' => (float) filter_input(INPUT_POST, 'surface', FILTER_VALIDATE_FLOAT),
+    'pesee_max' => (float) filter_input(INPUT_POST, 'pesee_max', FILTER_VALIDATE_FLOAT),
   ]);
   generic_insert_5Config($bdd, 'points_sortie', 'nom', 'adresse', 'pesee_max', $data);
 }


### PR DESCRIPTION
La fonction `point_sortiePost()` contenait une erreur de frappe.

Edit by @darnuria: En vertue de la licence du projet "AGPLV3" de
Oressource, je me permet de retroporter ce fix réalisé par @Ouari qui
n'a pas laissé de moyen de le contacté.