### PR TITLE
Impression/ajout/nom caissier

### DIFF
--- a/core/session.php
+++ b/core/session.php
@@ -34,6 +34,7 @@ function set_session(array $user, array $structure) {
   $_SESSION['taux_tva'] = $structure['taux_tva'];
   $_SESSION['structure'] = $structure['nom'];
   $_SESSION['siret'] = $structure['siret'];
+  $_SESSION['tel'] = $structure['telephone'];
   $_SESSION['adresse'] = $structure['adresse'];
   $_SESSION['texte_adhesion'] = $structure['texte_adhesion'];
   $_SESSION['lot_caisse'] = $structure['lot'];

--- a/ifaces/ventes.php
+++ b/ifaces/ventes.php
@@ -276,6 +276,7 @@ if (is_valid_session() && is_allowed_vente_id($numero)) {
       taux_tva: <?= json_encode($_SESSION['taux_tva'], JSON_NUMERIC_CHECK); ?>,
       point: <?= json_encode(points_ventes_id($bdd, $numero), JSON_NUMERIC_CHECK); ?>,
       id_user: <?= json_encode($_SESSION['id'], JSON_NUMERIC_CHECK) ?>,
+      nom_user: <?= json_encode($_SESSION['nom'], JSON_NUMERIC_CHECK) ?>,
       moyens_paiement: <?= json_encode($moyens_paiement, JSON_NUMERIC_CHECK) ?>
     };
 

--- a/ifaces/ventes.php
+++ b/ifaces/ventes.php
@@ -266,6 +266,8 @@ if (is_valid_session() && is_allowed_vente_id($numero)) {
     window.OressourceEnv = {
       structure: <?= json_encode($_SESSION['structure']) ?>,
       adresse: <?= json_encode($_SESSION['adresse']) ?>,
+      siret: <?= json_encode($_SESSION['siret']) ?>,
+      tel: <?= json_encode($_SESSION['tel']) ?>,
       nb_viz_caisse: <?= json_encode($_SESSION['nb_viz_caisse'], JSON_NUMERIC_CHECK); ?>,
       force_pes_vente: <?= json_encode($_SESSION['force_pes_vente']); ?>,
       pesees: <?= json_encode(pesees_ventes()) ?>,

--- a/js/utils.js
+++ b/js/utils.js
@@ -640,6 +640,7 @@ function impressionTicket(data, response, tvaStuff = () => '') {
       ${dashBreak}
       <h2>Type: ${classeToName(data.classe)} &#x2116;${response.id}</h2>
       <p>Le : ${moment().format('DD/MM/YYYY - HH:mm')}</p>
+      <p>Caisse : ${window.OressourceEnv.nom_user}</p>
       <strong>${tvaStuff()}</strong>
       <p>${showPaiement(data.id_moyen)}</p>
       <p>Nb articles : ${state.ticket.sum_quantite()}</p>

--- a/js/utils.js
+++ b/js/utils.js
@@ -632,16 +632,31 @@ function impressionTicket(data, response, tvaStuff = () => '') {
     <link rel="stylesheet" href="../css/ticket_impression.css" type="text/css">
     </head>
     <body>
-      <p>${document.querySelector('h1').innerHTML}</p>
-      <p>${window.OressourceEnv.structure}</p>
+      <h1>${window.OressourceEnv.structure}</h1>
+      <h2>${document.querySelector('h1').innerHTML}</h2>
       <p>${window.OressourceEnv.adresse}</p>
+      <p>SIRET : ${window.OressourceEnv.siret}</p>
+      <p>tel : ${window.OressourceEnv.tel}</p>
       ${dashBreak}
-      <p>Type: ${classeToName(data.classe)} &#x2116;${response.id}</p>
-      ${tvaStuff()}
-      ${showPaiement(data.id_moyen)}
+      <h2>Type: ${classeToName(data.classe)} &#x2116;${response.id}</h2>
+      <p>Le : ${moment().format('DD/MM/YYYY - HH:mm')}</p>
+      <strong>${tvaStuff()}</strong>
+      <p>${showPaiement(data.id_moyen)}</p>
+      <p>Nb articles : ${state.ticket.sum_quantite()}</p>
+      ${dashBreak}
+      <h2>Détail des articles</h2>
+      <table>
+        <caption>Nombre de lignes éditées : ${data.items.length}</caption>
+        <tr>
+          <th width= "5px"> Qte </th>
+          <th width= "20px"> Nom objet </th>
+          <th width= "8px"> P.U. € </th>
+          <th width= "10px"> Total </th>
+        </tr>
+        ${showTickets(data, unit)}
+      </table>
+      ${dashBreak}
       <p>Ticket client à conserver.</p>
-      <p>Date d'édition du ticket : ${moment().format('DD/MM/YYYY - HH:mm')}</p>
-      ${showTickets(data)}
     </body>
   </html>`;
 


### PR DESCRIPTION
@mart1ver et historiquement voulions eviter cette fonctionnalité. Je garde la branche ouvert pour les personnes qui voudraient cette fonctionnalité sans accord explicite de @mart1ver je vais pas merger ce commit 40a287c.

La raison derrière est que nous ne voulons pas reproduires certains schema des logiciels de caisse existants, le nom du caissier est pas indispensable, au pire le numero nom du point de vente oui.