### PR TITLE
Retour de l'export mysql

### DIFF
--- a/ifaces/exportbase.php
+++ b/ifaces/exportbase.php
@@ -63,7 +63,8 @@ if (is_valid_session() && is_allowed_config()) {
   $struct = structure($bdd)['nom'];
 
   # Go into the ./mysql folder
-  $exportPath = '../mysql/';
+  $exportPath = sys_get_temp_dir(). DIRECTORY_SEPARATOR. 'oressouce_mysql';
+  mkdir($exportPath, 0755);
   chdir($exportPath);
 
   # Name the sql dump file
@@ -73,29 +74,25 @@ if (is_valid_session() && is_allowed_config()) {
 
   # Dump the database via mysqldump (provided by mysql-client)
   $worked = exec("mysqldump --opt --host=$host --user=$user --password=$pass $base > \"$exportPathServer\"");
-
+  if ($worked === false) {
+    header("Location:structures.php?err=Probleme%20pendant%20l'export%20du%20fichier");
+    exit;
+  }
   // Remove spaces from name and name the zip file
   $struct = str_replace(" ", "_", $struct);
   $fileZip = $exportFileName . '_' . $struct . '.zip';
 
   # Zip the sql file
-  $worked |= exec("zip \"$fileZip\" \"$exportPathServer\"");
+  $worked = exec("zip \"$fileZip\" \"$exportPathServer\"");
+  if ($worked === false) {
+    header("Location:structures.php?err=Probleme%20pendant%20l'export%20de%20la%20base");
+    exit;
+  }
 
   // Delete sql file
   unlink($exportPathServer);
-
-  switch ($worked) {
-    case 0:
-      $AttachName = $exportFileName . '_' . $struct . '_' . date("d-m-Y_H-i-s") . '.zip';
-      download($fileZip, 'application/octet-stream', $AttachName);
-      break;
-    case 1:
-      header("Location:structures.php?err=Probleme pendant l'export du fichier");
-      break;
-    case 2:
-      header("Location:structures.php?err=Probleme pendant l'export de la base");
-      break;
-  }
+  $AttachName = $exportFileName . '_' . $struct . '_' . date("d-m-Y_H-i-s") . '.zip';
+  download($fileZip, 'application/octet-stream', $AttachName);
 } else {
   header('Location:../moteur/destroy.php');
 }


### PR DESCRIPTION
L’export des données n'étant plus fonctionnel, cette petite correction vise à permettre aux utilisateurs actuels du dépôt de faire des ces sauvegardes de la base.